### PR TITLE
Added additional build information

### DIFF
--- a/Plugins/PrefirePlaybookPlugin/Plugin.swift
+++ b/Plugins/PrefirePlaybookPlugin/Plugin.swift
@@ -5,14 +5,12 @@ import PackagePlugin
 struct PrefirePlaybookPlugin: BuildToolPlugin {
     func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
         let executable = try context.tool(named: "PrefireSourcery").path
-        let templatesDirectory = executable.string.components(separatedBy: "Binaries").first! + "Templates"
 
         try FileManager.default.createDirectory(atPath: context.pluginWorkDirectory.string, withIntermediateDirectories: true)
 
         return [
             Command.prefireCommand(
                 executablePath: executable,
-                templatesDirectory: templatesDirectory,
                 sources: target.directory,
                 generatedSourcesDirectory: context.pluginWorkDirectory)
         ]
@@ -25,14 +23,12 @@ import XcodeProjectPlugin
 extension PrefirePlaybookPlugin: XcodeBuildToolPlugin {
     func createBuildCommands(context: XcodeProjectPlugin.XcodePluginContext, target: XcodeProjectPlugin.XcodeTarget) throws -> [PackagePlugin.Command] {
         let executable = try context.tool(named: "PrefireSourcery").path
-        let templatesDirectory = executable.string.components(separatedBy: "Binaries").first! + "Templates"
 
         try FileManager.default.createDirectory(atPath: context.pluginWorkDirectory.string, withIntermediateDirectories: true)
 
         return [
             Command.prefireCommand(
                 executablePath: executable,
-                templatesDirectory: templatesDirectory,
                 sources: context.xcodeProject.directory,
                 generatedSourcesDirectory: context.pluginWorkDirectory)
         ]
@@ -45,11 +41,20 @@ extension PrefirePlaybookPlugin: XcodeBuildToolPlugin {
 extension Command {
     static func prefireCommand(
         executablePath executable: Path,
-        templatesDirectory: String,
         sources: Path,
         generatedSourcesDirectory: Path
     ) -> Command {
-        Command.prebuildCommand(
+        Diagnostics.remark(
+        """
+        Prefire configuration
+        Preview sources path: \(sources.string)
+        Generated preview models path: \(generatedSourcesDirectory)/PreviewModels.generated.swift
+        """
+        )
+
+        let templatesDirectory = executable.string.components(separatedBy: "Binaries").first! + "Templates"
+
+        return Command.prebuildCommand(
             displayName: "Running Prefire",
             executable: executable,
             arguments: [

--- a/Plugins/PrefireTestsPlugin/Configuration.swift
+++ b/Plugins/PrefireTestsPlugin/Configuration.swift
@@ -20,12 +20,24 @@ extension Configuration {
 
     private static let fileName = ".prefire.yml"
 
-    static func from(rootPath: Path) -> Configuration? {
+    static func from(rootPaths: [Path]) -> Configuration? {
+        for path in rootPaths {
+            if let configuration = Configuration.from(rootPath: path) {
+                return configuration
+            }
+        }
+        return nil
+    }
+
+    private static func from(rootPath: Path) -> Configuration? {
         let configPath = rootPath.appending(subpath: Configuration.fileName)
+        Diagnostics.remark("Trying to find a '.prefire.yml' from the path: \(configPath.string)")
 
         guard FileManager.default.fileExists(atPath: configPath.string),
               let configDataString = URL(string: "file://\(configPath)").flatMap({ try? String(contentsOf: $0, encoding: .utf8) })
         else { return nil }
+
+        Diagnostics.remark("🟢 Successfully found and will use the file '.prefire.yml' on the path: \(configPath.string)")
 
         return Configuration(
             targetName: getFrom(configDataString: configDataString, key: .target),


### PR DESCRIPTION
To understand which configuration was picked up, additional information was added during the build of the plugin:

For **PrefirePlaybookPlugin**:
![Screenshot 2023-06-05 at 11 33 32](https://github.com/BarredEwe/Prefire/assets/19188911/008fbb09-0821-40d2-b583-d3788ed3585e)

For  **PrefireTestsPlugin**:
![Screenshot 2023-06-05 at 11 34 59](https://github.com/BarredEwe/Prefire/assets/19188911/8fe69f75-f68f-421c-a6f1-ca0606846f63)
