### PR TITLE
Improved target search for tests

### DIFF
--- a/Plugins/PrefireTestsPlugin/Configuration.swift
+++ b/Plugins/PrefireTestsPlugin/Configuration.swift
@@ -30,14 +30,13 @@ extension Configuration {
     }
 
     private static func from(rootPath: Path) -> Configuration? {
-        let configPath = rootPath.appending(subpath: Configuration.fileName)
-        Diagnostics.remark("Trying to find a '.prefire.yml' from the path: \(configPath.string)")
+        let configUrl = URL(fileURLWithPath: rootPath.appending(subpath: Configuration.fileName).string)
+        Diagnostics.remark("Trying to find a '.prefire.yml' from the path: \(configUrl.path)")
 
-        guard FileManager.default.fileExists(atPath: configPath.string),
-              let configDataString = URL(string: "file://\(configPath)").flatMap({ try? String(contentsOf: $0, encoding: .utf8) })
-        else { return nil }
+        guard FileManager.default.fileExists(atPath: configUrl.path),
+              let configDataString = try? String(contentsOf: configUrl, encoding: .utf8) else { return nil }
 
-        Diagnostics.remark("🟢 Successfully found and will use the file '.prefire.yml' on the path: \(configPath.string)")
+        Diagnostics.remark("🟢 Successfully found and will use the file '.prefire.yml' on the path: \(configUrl.path)")
 
         return Configuration(
             targetName: getFrom(configDataString: configDataString, key: .target),

--- a/Plugins/PrefireTestsPlugin/Plugin.swift
+++ b/Plugins/PrefireTestsPlugin/Plugin.swift
@@ -8,7 +8,8 @@ struct PrefireTestsPlugin: BuildToolPlugin {
 
         let configuration = Configuration.from(rootPaths: [target.directory, target.directory.removingLastComponent()])
 
-        guard let mainTarget = context.package.targets.first(where: { $0.name == configuration?.targetName }) ?? context.package.targets.first else {
+        guard let mainTarget = context.package.targets.first(where: { $0.name == configuration?.targetName }) ??
+                context.package.targets.first(where: { $0.name != target.name }) else {
             throw "Prefire cannot find target for testing. Please, use `.prefire.yml` file, for providing `Target Name`"
         }
 
@@ -40,9 +41,10 @@ extension PrefireTestsPlugin: XcodeBuildToolPlugin {
 
         let configuration = Configuration.from(rootPaths: [context.xcodeProject.directory.appending(subpath: target.displayName), context.xcodeProject.directory])
 
-        guard let targetName = configuration?.targetName ?? context.xcodeProject.targets.first?.displayName else {
+        guard let targetName = configuration?.targetName ?? context.xcodeProject.targets.first(where: { $0.displayName != target.displayName })?.displayName else {
             throw "Prefire cannot find target for testing. Please, use `.prefire.yml` file, for providing `Target Name`"
         }
+
         let testFilePath = configuration?.testFilePath.flatMap({ context.xcodeProject.directory.appending(subpath: $0).string }) ??
             "\(context.pluginWorkDirectory)/\(target.displayName)/PreviewTests.generated.swift"
 

--- a/README.md
+++ b/README.md
@@ -68,10 +68,14 @@ dependencies: [
     plugins: [
         // For Playbook (Demo) view
         .plugin(name: "PrefirePlaybookPlugin", package: "Prefire")
+    ]
+),
+.testTarget(
+    plugins: [
         // For Snapshot Tests
         .plugin(name: "PrefireTestsPlugin", package: "Prefire")
     ]
-),
+)
 ```
 
 ---


### PR DESCRIPTION
Improved target search for tests:
- Added filtering of the current target

Added separation of plug-ins connection to the documentation:
```swift
.target(
    plugins: [
        // For Playbook (Demo) view
        .plugin(name: "PrefirePlaybookPlugin", package: "Prefire")
    ]
),
.testTarget(
    plugins: [
        // For Snapshot Tests
        .plugin(name: "PrefireTestsPlugin", package: "Prefire")
    ]
)
```