### PR TITLE
Fix command in README to run Prefire via CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ SWIFT_ACTIVE_COMPILATION_CONDITIONS = NO_PLAYBOOK;
 
 Running Prefire via CI
 - To run Prefire via Continuous Integration (CI), you need to configure permissions:
-`defaults write com.apple.dt.Xcode ideskippackagepluginfingerprintvalidationbool YES`
+`defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidatation -bool YES`
 
 Xcode is unable to generate tests in a custom path.
 - To resolve this, you’ll need to disable the sandbox for file generation by running the following command in your terminal:


### PR DESCRIPTION
The command to disable package plugin fingerprint validation is `defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidatation -bool YES`

Closes #66