### PR TITLE
Add case insensitive searching to playbook view

### DIFF
--- a/Sources/Prefire/Playbook/PlaybookView.swift
+++ b/Sources/Prefire/Playbook/PlaybookView.swift
@@ -39,7 +39,7 @@ public struct PlaybookView: View {
             ScrollView {
                 VStack {
                     ForEach(sectionNames, id: \.self) { name in
-                        if searchText.isEmpty || name.contains(searchText) {
+                        if searchText.isEmpty || name.lowercased().contains(searchText.lowercased()) {
                             VStack(alignment: .leading) {
                                 Text(isComponent ? name : "📙 \(name.capitalized)")
                                     .font(.title.bold())


### PR DESCRIPTION
### Short description 📝
Implement a case-insensitive search functionality to improve user experience by allowing searches that ignore capitalization differences. This ensures more flexibility and convenience in matching search terms regardless of letter case.

### Solution 📦
The solution is to change the search logic to treat uppercase and lowercase equally. This was achieved by converting both the search input and the searchable content to a common case (e.g. lowercase) before performing the comparison.

### Implementation 👩‍💻👨‍💻
Modify the search function to make it case-insensitive.
