### PR TITLE
tvOS Support

### DIFF
--- a/Example/.prefire.yml
+++ b/Example/.prefire.yml
@@ -1,10 +1,9 @@
 test_configuration:
   - target: PrefireExample
-  - simulator_device: "iPhone17,1"
+  - simulator_device: "AppleTV5,3"
   - required_os: 18
   - snapshot_devices:
-      - iPhone 15
-      - iPad
+      - Apple TV
   - imports:
       - UIKit
       - Foundation

--- a/Example/.prefire.yml
+++ b/Example/.prefire.yml
@@ -1,9 +1,10 @@
 test_configuration:
   - target: PrefireExample
-  - simulator_device: "AppleTV5,3"
+  - simulator_device: "iPhone17,1"
   - required_os: 18
   - snapshot_devices:
-      - Apple TV
+      - iPhone 15
+      - iPad
   - imports:
       - UIKit
       - Foundation

--- a/Example/PreFireExample.xcodeproj/project.pbxproj
+++ b/Example/PreFireExample.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		97078E162AF7F2A50041AFB7 /* PrefireExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97078E152AF7F2A50041AFB7 /* PrefireExampleTests.swift */; };
-		971620D128EEC49A001B8EE3 /* AccessibilitySnapshot in Frameworks */ = {isa = PBXBuildFile; productRef = 971620D028EEC49A001B8EE3 /* AccessibilitySnapshot */; };
 		9735EE38289C5CF300309267 /* PrefireExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9735EE28289C5CF200309267 /* PrefireExampleApp.swift */; };
 		9735EE3C289C5CF300309267 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9735EE2A289C5CF300309267 /* Assets.xcassets */; };
 		9735EE49289C5F3A00309267 /* TestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9735EE48289C5F3A00309267 /* TestView.swift */; };
@@ -60,7 +59,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				9779D5F428A3F13F0083DBD3 /* SnapshotTesting in Frameworks */,
-				971620D128EEC49A001B8EE3 /* AccessibilitySnapshot in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/PreFireExample.xcodeproj/project.pbxproj
+++ b/Example/PreFireExample.xcodeproj/project.pbxproj
@@ -200,7 +200,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 9735EE26289C5CF200309267 /* Build configuration list for PBXProject "PrefireExample" */;
+			buildConfigurationList = 9735EE26289C5CF200309267 /* Build configuration list for PBXProject "PreFireExample" */;
 			compatibilityVersion = "Xcode 13.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -424,9 +424,13 @@
 				PRODUCT_BUNDLE_IDENTIFIER = barred.ewe.prefire.example;
 				PRODUCT_NAME = PrefireExample;
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,3";
 			};
 			name = Debug;
 		};
@@ -454,9 +458,13 @@
 				PRODUCT_BUNDLE_IDENTIFIER = barred.ewe.prefire.example;
 				PRODUCT_NAME = PrefireExample;
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,3";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -480,10 +488,14 @@
 				PRODUCT_BUNDLE_IDENTIFIER = barred.ewe.PreFireExampleTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 6.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,3";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PrefireExample.app/PrefireExample";
 			};
 			name = Debug;
@@ -507,9 +519,13 @@
 				PRODUCT_BUNDLE_IDENTIFIER = barred.ewe.PreFireExampleTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 6.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,3";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PrefireExample.app/PrefireExample";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -518,7 +534,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		9735EE26289C5CF200309267 /* Build configuration list for PBXProject "PrefireExample" */ = {
+		9735EE26289C5CF200309267 /* Build configuration list for PBXProject "PreFireExample" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				9735EE3E289C5CF300309267 /* Debug */,

--- a/Example/PreFireExample.xcodeproj/project.pbxproj
+++ b/Example/PreFireExample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6EBCE0172D124ABF009ACE0B /* AccessibilitySnapshot in Frameworks */ = {isa = PBXBuildFile; productRef = 6EBCE0162D124ABF009ACE0B /* AccessibilitySnapshot */; };
 		97078E162AF7F2A50041AFB7 /* PrefireExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97078E152AF7F2A50041AFB7 /* PrefireExampleTests.swift */; };
 		9735EE38289C5CF300309267 /* PrefireExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9735EE28289C5CF200309267 /* PrefireExampleApp.swift */; };
 		9735EE3C289C5CF300309267 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9735EE2A289C5CF300309267 /* Assets.xcassets */; };
@@ -59,6 +60,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9779D5F428A3F13F0083DBD3 /* SnapshotTesting in Frameworks */,
+				6EBCE0172D124ABF009ACE0B /* AccessibilitySnapshot in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -172,7 +174,7 @@
 			name = PrefireExampleTests;
 			packageProductDependencies = (
 				9779D5F328A3F13F0083DBD3 /* SnapshotTesting */,
-				971620D028EEC49A001B8EE3 /* AccessibilitySnapshot */,
+				6EBCE0162D124ABF009ACE0B /* AccessibilitySnapshot */,
 			);
 			productName = SnapshotAppSwiftUITests;
 			productReference = 9779D5E628A3ECBA0083DBD3 /* PrefireExampleTests.xctest */;
@@ -209,7 +211,7 @@
 			mainGroup = 9735EE22289C5CF200309267;
 			packageReferences = (
 				9779D5F228A3F13F0083DBD3 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */,
-				971620CF28EEC49A001B8EE3 /* XCRemoteSwiftPackageReference "AccessibilitySnapshot" */,
+				6EBCE0152D124ABF009ACE0B /* XCRemoteSwiftPackageReference "AccessibilitySnapshot" */,
 			);
 			productRefGroup = 9735EE30289C5CF300309267 /* Products */;
 			projectDirPath = "";
@@ -562,12 +564,12 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		971620CF28EEC49A001B8EE3 /* XCRemoteSwiftPackageReference "AccessibilitySnapshot" */ = {
+		6EBCE0152D124ABF009ACE0B /* XCRemoteSwiftPackageReference "AccessibilitySnapshot" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/cashapp/AccessibilitySnapshot";
+			repositoryURL = "https://github.com/cashapp/AccessibilitySnapshot.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.5.1;
+				minimumVersion = 0.8.0;
 			};
 		};
 		9779D5F228A3F13F0083DBD3 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {
@@ -581,9 +583,9 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		971620D028EEC49A001B8EE3 /* AccessibilitySnapshot */ = {
+		6EBCE0162D124ABF009ACE0B /* AccessibilitySnapshot */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 971620CF28EEC49A001B8EE3 /* XCRemoteSwiftPackageReference "AccessibilitySnapshot" */;
+			package = 6EBCE0152D124ABF009ACE0B /* XCRemoteSwiftPackageReference "AccessibilitySnapshot" */;
 			productName = AccessibilitySnapshot;
 		};
 		9779D5F328A3F13F0083DBD3 /* SnapshotTesting */ = {

--- a/Example/PreFireExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/PreFireExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,13 @@
 {
+  "originHash" : "ac988f1bdd201a27034cd4efa451ebe5806e0fd8b0ac226a19cbd79e07ebdb21",
   "pins" : [
     {
       "identity" : "accessibilitysnapshot",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/cashapp/AccessibilitySnapshot",
       "state" : {
-        "revision" : "482db2fd4251cce237d8106073a53ad5289ce739",
-        "version" : "0.6.0"
+        "revision" : "07020833b49662840e92d6b1ad2bcfa9916a10d6",
+        "version" : "0.8.0"
       }
     },
     {
@@ -37,5 +38,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Example/PreFireExample.xcodeproj/xcshareddata/xcschemes/PrefireExample.xcscheme
+++ b/Example/PreFireExample.xcodeproj/xcshareddata/xcschemes/PrefireExample.xcscheme
@@ -17,7 +17,7 @@
                BlueprintIdentifier = "9735EE2E289C5CF300309267"
                BuildableName = "PrefireExample.app"
                BlueprintName = "PrefireExample"
-               ReferencedContainer = "container:PrefireExample.xcodeproj">
+               ReferencedContainer = "container:PreFireExample.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -35,7 +35,7 @@
                BlueprintIdentifier = "9779D5E528A3ECBA0083DBD3"
                BuildableName = "PrefireExampleTests.xctest"
                BlueprintName = "PrefireExampleTests"
-               ReferencedContainer = "container:PrefireExample.xcodeproj">
+               ReferencedContainer = "container:PreFireExample.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>
@@ -57,7 +57,7 @@
             BlueprintIdentifier = "9735EE2E289C5CF300309267"
             BuildableName = "PrefireExample.app"
             BlueprintName = "PrefireExample"
-            ReferencedContainer = "container:PrefireExample.xcodeproj">
+            ReferencedContainer = "container:PreFireExample.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </LaunchAction>
@@ -74,7 +74,7 @@
             BlueprintIdentifier = "9735EE2E289C5CF300309267"
             BuildableName = "PrefireExample.app"
             BlueprintName = "PrefireExample"
-            ReferencedContainer = "container:PrefireExample.xcodeproj">
+            ReferencedContainer = "container:PreFireExample.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>

--- a/Example/Shared/Examples/AuthView.swift
+++ b/Example/Shared/Examples/AuthView.swift
@@ -29,7 +29,6 @@ struct AuthView: View {
                 }
                 .tint(.black.opacity(0.9))
                 .buttonStyle(.borderedProminent)
-                .controlSize(.large)
                 .disabled(login.isEmpty && password.isEmpty)
 
                 Button {
@@ -40,7 +39,6 @@ struct AuthView: View {
                 }
                 .tint(.accentColor)
                 .buttonStyle(.bordered)
-                .controlSize(.large)
             }
             .padding()
 

--- a/Example/Shared/MainMenu.swift
+++ b/Example/Shared/MainMenu.swift
@@ -2,6 +2,7 @@ import Prefire
 import SwiftUI
 
 struct MainMenu: View {
+#if os(iOS)
     var body: some View {
         NavigationView {
             Form {
@@ -22,6 +23,11 @@ struct MainMenu: View {
             .navigationTitle("SwiftUI System")
         }
     }
+#else
+    var body: some View {
+        Text("tvOS not yet supported")
+    }
+#endif
 }
 
 struct MainMenu_Previews: PreviewProvider {

--- a/Sources/Prefire/Playbook/PlaybookView.swift
+++ b/Sources/Prefire/Playbook/PlaybookView.swift
@@ -13,6 +13,8 @@ extension CGFloat {
 /// Can display Previews in two types:
 /// - `isComponent: false // Sorted by Flow`
 /// - `isComponent: true  // Sorted by screen or component name`
+#if os(iOS)
+@available(tvOS, unavailable)
 public struct PlaybookView: View {
     @State private var navigationLinkTriggered: Bool = false
     @State private var selectedId: String = ""
@@ -252,3 +254,4 @@ struct ContentView_Previews: PreviewProvider {
         )
     }
 }
+#endif

--- a/Templates/PreviewTests.stencil
+++ b/Templates/PreviewTests.stencil
@@ -19,11 +19,15 @@ import {{ import }}
 #endif
 
 @MainActor class PreviewTests: XCTestCase, Sendable {
-    private let deviceConfig: ViewImageConfig = .iPhoneX
     private var simulatorDevice: String?{% if argument.simulatorDevice %} = "{{ argument.simulatorDevice|default:nil }}"{% endif %}
     private var requiredOSVersion: Int?{% if argument.simulatorOSVersion %} = {{ argument.simulatorOSVersion }}{% endif %}
     private let snapshotDevices: [String]{% if argument.snapshotDevices %} = {{ argument.snapshotDevices|split:"|" }}{% else %} = []{% endif %}
-    
+#if os(iOS)
+    private let deviceConfig: ViewImageConfig = .iPhoneX
+#elseif os(tvOS)
+    private let deviceConfig: ViewImageConfig = .tv
+#endif
+
     
     {% if argument.file %}
 
@@ -188,6 +192,7 @@ import {{ import }}
 private extension PreviewDevice {
     func snapshotDevice() -> ViewImageConfig? {
         switch rawValue {
+#if os(iOS)
         case "iPhone 16 Pro Max", "iPhone 15 Pro Max", "iPhone 14 Pro Max", "iPhone 13 Pro Max", "iPhone 12 Pro Max":
             return .iPhone13ProMax
         case "iPhone 16 Pro", "iPhone 15 Pro", "iPhone 14 Pro", "iPhone 13 Pro", "iPhone 12 Pro":
@@ -208,6 +213,10 @@ private extension PreviewDevice {
             return .iPadPro11
         case "iPad Pro 12.9":
             return .iPadPro12_9
+#elseif os(tvOS)
+        case "Apple TV":
+            return .tv        
+#endif
         default: return nil
         }
     }


### PR DESCRIPTION
Here's some work to add tvOS compatibility.

Resolves #87

We may need to amend the `.prefire.yml` to add Apple TV configs?


```yaml
test_configuration:
  - target: PrefireExample
  - simulator_device: "iPhone17,1"
  - required_os: 18
  - snapshot_devices:
      - iPhone 15
      - iPad
  - tv_snapshot_devices:
      - Apple TV 4K
      - Apple TV HD
  - tv_simulator_device: "AppleTV11,1"
  - imports:
      - UIKit
      - Foundation

playbook_configuration:
  - imports:
      - UIKit
      - Foundation
```