### PR TITLE
Add ui-testing

### DIFF
--- a/Plugins/PrefireTestsPlugin/TestedTargetFinder.swift
+++ b/Plugins/PrefireTestsPlugin/TestedTargetFinder.swift
@@ -81,9 +81,14 @@ extension TestedTargetFinder {
 
 extension XcodeTarget {
     var isTestKind: Bool {
-        if case .other("com.apple.product-type.bundle.unit-test") = product?.kind {
+        guard let kind = product?.kind
+        else { return false }
+
+        switch kind {
+        case .other("com.apple.product-type.bundle.unit-test"),
+             .other("com.apple.product-type.bundle.ui-testing"):
             return true
-        } else {
+        default:
             return false
         }
     }


### PR DESCRIPTION
### Short description 📝

Added bundle.unit-test

### Implementation 👩‍💻👨‍💻

This pull request includes a change to the `TestedTargetFinder` extension in `Plugins/PrefireTestsPlugin/TestedTargetFinder.swift`. The change refactors the `isTestKind` property to improve readability and extend its functionality.

Refactor and functionality extension:

* [`Plugins/PrefireTestsPlugin/TestedTargetFinder.swift`](diffhunk://#diff-4f68dc823f6bb2a7c1df9960e7cdb70e072b5b2868c52be52873acd80231ee9dL84-R91): Refactored the `isTestKind` property to use a `guard` statement and switch-case structure, and added support for `com.apple.product-type.bundle.ui-testing` in addition to `com.apple.product-type.bundle.unit-test`.