### PR TITLE
Add PreferenceKey to override an existing snapshot and record a new one.

### DIFF
--- a/Sources/Prefire/Preview/PreferenceKeys.swift
+++ b/Sources/Prefire/Preview/PreferenceKeys.swift
@@ -66,6 +66,14 @@ public struct PerceptualPrecisionPreferenceKey: PreferenceKey {
     }
 }
 
+public struct RecordPreferenceKey: PreferenceKey {
+    public static let defaultValue: Bool = false
+
+    public static func reduce(value: inout Bool, nextValue: () -> Bool) {
+        value = nextValue()
+    }
+}
+
 public extension View {
     /// Use this modifier when you want to apply snapshot-specific preferences,
     /// like delay and precision, to the view.
@@ -75,10 +83,12 @@ public extension View {
     ///   - delay: The delay time in seconds that you want to set as a preference to the View.
     ///   - precision: The percentage of pixels that must match.
     ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. 98-99% mimics the precision of the human eye.
+    ///   - record: Whether or not to override the existing snapshot and record a new one.
     @inlinable
-    func snapshot(delay: TimeInterval = .zero, precision: Float = 1.0, perceptualPrecision: Float = 1.0) -> some View {
+    func snapshot(delay: TimeInterval = .zero, precision: Float = 1.0, perceptualPrecision: Float = 1.0, record: Bool = false) -> some View {
         preference(key: DelayPreferenceKey.self, value: delay)
             .preference(key: PrecisionPreferenceKey.self, value: precision)
             .preference(key: PerceptualPrecisionPreferenceKey.self, value: perceptualPrecision)
+            .preference(key: RecordPreferenceKey.self, value: record)
     }
 }

--- a/Templates/PreviewTests.stencil
+++ b/Templates/PreviewTests.stencil
@@ -95,11 +95,13 @@ import {{ import }}
         var delay: TimeInterval = 0
         var precision: Float = 1
         var perceptualPrecision: Float = 1
+        var record: Bool = false
 
         let view = prefireSnapshot.content
             .onPreferenceChange(DelayPreferenceKey.self) { delay = $0 }
             .onPreferenceChange(PrecisionPreferenceKey.self) { precision = $0 }
             .onPreferenceChange(PerceptualPrecisionPreferenceKey.self) { perceptualPrecision = $0 }
+            .onPreferenceChange(RecordPreferenceKey.self) { record = $0 }
 
         let matchingView = prefireSnapshot.isScreen ? AnyView(view) : AnyView(view
             .frame(width: prefireSnapshot.device.size?.width)
@@ -113,6 +115,7 @@ import {{ import }}
                               duration: { delay },
                               layout: prefireSnapshot.isScreen ? .device(config: prefireSnapshot.device) : .sizeThatFits,
                               traits: prefireSnapshot.traits){% if argument.file %},
+            record: record,
             file: file{% endif %},
             testName: prefireSnapshot.name
         )
@@ -124,6 +127,7 @@ import {{ import }}
             SnapshotTesting.assertSnapshot(
                 matching: vc,
                 as: .wait(for: delay, on: .accessibilityImage(showActivationPoints: .always)){% if argument.file %},
+                record: record,
                 file: file{% endif %},
                 testName: prefireSnapshot.name + ".accessibility"
             )


### PR DESCRIPTION
### Short description 📝
It would be nice to easily determine which snapshots to re-record without having to find the snapshot images themselves to delete them.

### Solution 📦
Add a PreferenceKey called `RecordPreferenceKey` that you can add to the `.snapshot()` function to indicate that snapshot should be re-recoreded

### Implementation 👩‍💻👨‍💻
1) Add `RecordPreferenceKey` in `PreferenceKeys.swift`
2) Add `record` param to `snapshot(...)`
3) Use preference key in `PreviewTests.stencil` so it will be used in the generated code.