### PR TITLE
Add environments for plugins

### DIFF
--- a/Plugins/PrefireTestsPlugin/Plugin.swift
+++ b/Plugins/PrefireTestsPlugin/Plugin.swift
@@ -31,11 +31,16 @@ struct PrefireTestsPlugin: BuildToolPlugin {
         let sources = testedTarget.sourceFiles.filter { $0.type == .source }.map(\.path.string)
         arguments.append(contentsOf: sources)
 
+        let environment = [
+            "TARGET_DIR": target.directory.string,
+        ]
+
         return [
             .prebuildCommand(
                 displayName: "Running Prefire",
                 executable: executable,
                 arguments: arguments,
+                environment: environment,
                 outputFilesDirectory: outputPath
             ),
         ]
@@ -74,11 +79,16 @@ struct PrefireTestsPlugin: BuildToolPlugin {
             let sources = testedTarget.inputFiles.filter { $0.type == .source }.map(\.path.string)
             arguments.append(contentsOf: sources)
 
+            let environment = [
+                "PROJECT_DIR": context.xcodeProject.directory.string,
+            ]
+
             return [
                 .prebuildCommand(
                     displayName: "Running Prefire Tests",
                     executable: executable,
                     arguments: arguments,
+                    environment: environment,
                     outputFilesDirectory: outputPath
                 ),
             ]


### PR DESCRIPTION
### Short description 📝
Add enviroment to prebuildCommand in plugins.

### Solution 📦

At the moment we can't use environment variables in config file. This is because they are not passed to the plugin and we need initialize them yourself. 
This config will not work correctly. The plugins does not create snapshots along this path.
```
test_configuration:
....
  - sources:
    - ${PROJECT_DIR}/Sources/
...
```

### Implementation 👩‍💻👨‍💻

- Add `PROJECT_DIR` variable to XcodePlugin
- Add `TARGET_DIR` variable for spm plugin.
