### PR TITLE
Fix: Inline comments break `prefireIgnored()`

### DIFF
--- a/PrefireExecutable/Sources/prefire/Previews/PreviewLoader.swift
+++ b/PrefireExecutable/Sources/prefire/Previews/PreviewLoader.swift
@@ -89,11 +89,11 @@ enum PreviewLoader {
             }
 
             if defaultEnabled {
-                if line.hasSuffix(Constants.prefireDisableMarker) {
+                if line.contains(Constants.prefireDisableMarker) {
                     viewMustBeLoaded = false
                 }
             } else if !viewMustBeLoaded {
-                viewMustBeLoaded = line.hasSuffix(Constants.prefireEnabledMarker)
+                viewMustBeLoaded = line.contains(Constants.prefireEnabledMarker)
             }
 
             currentBody.append(String(line) + "\n")

--- a/PrefireExecutable/Tests/PrefireTests/PreviewLoaderTests/PreviewLoaderTests.swift
+++ b/PrefireExecutable/Tests/PrefireTests/PreviewLoaderTests/PreviewLoaderTests.swift
@@ -5,7 +5,7 @@ import XCTest
 class PreviewLoaderTests: XCTestCase {
     var previewRepresentations = [
         "#Preview {\n    Text(\"TestView\")\n}\n",
-        "#Preview {\n    Text(\"TestView_Prefire\")\n        .prefireEnabled()\n}\n"
+        "#Preview {\n    Text(\"TestView_Prefire\")\n        .prefireEnabled()\n}\n",
     ]
 
     let source = #filePath
@@ -74,7 +74,12 @@ import SwiftUI
 
 #Preview {
     Text("TestView_Ignored")
-        .prefireIgnored()
+        // Some comment
+        .prefireIgnored() // Some comment
+}
+
+#Preview {
+    Text("TestView_Ignored_One_Line").prefireIgnored() // Some comment
 }
 
 extension View {


### PR DESCRIPTION
### Short description 📝
When adding `prefireIgnored()` to a preview with an inline comment, the modifier seems to be ignored.

```swift

// ✅ this works
MyView()
   // disabling this test
   .prefireIgnored()

// ❌ this does not work
MyView()
   .prefireIgnored() // disabling this test
```
Fix: https://github.com/BarredEwe/Prefire/issues/109

### Solution 📦
Added check via `contains`

### Implementation 👩‍💻👨‍💻
```swift
line.contains(Constants.prefireDisableMarker)
```