### PR TITLE
Bug fix for loading preferences

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,7 @@ jobs:
     permissions: write-all
     steps:
       - name: Create achrive
-        run: |
-          make achive    
+        run: make build
 
       - name: Upload Release
         uses: actions/upload-artifact@v4

--- a/Templates/PreviewTests.stencil
+++ b/Templates/PreviewTests.stencil
@@ -105,6 +105,16 @@ import {{ import }}
             .fixedSize(horizontal: false, vertical: true)
         )
 
+        // In order to call onPreferenceChange, render the view once
+        let hostingController = UIHostingController(rootView: matchingView)
+        let window = UIWindow(frame: .init())
+        window.isHidden = false
+        window.rootViewController = hostingController
+        hostingController.beginAppearanceTransition(true, animated: false)
+        hostingController.endAppearanceTransition()
+        hostingController.view.setNeedsLayout()
+        hostingController.view.layoutIfNeeded()
+
         let failure = verifySnapshot(
             of: matchingView,
             as: .prefireImage(precision: { preferences.precision },


### PR DESCRIPTION
### Short description 📝

This Pull Request addresses the issue where the solution in #107 does not resolve the problem with the following code:

```swift
extension View {
  func defaultSnapshotSettings() -> some View {
    snapshot(
      precision: 1.0,
      perceptualPrecision: 1.0,
      record: true
    )
  }
}

#Preview {
  Text("")
    .defaultSnapshotSettings()
}
```

### Solution 📦

The solution is to ensure that preferences are read properly. By rendering the view once before calling verifySnapshot, the onPreferenceChange gets called, ensuring that verifySnapshot is invoked afterwards.
