### PR TITLE
Fix to Ensure onPreferenceChange is Called

### DIFF
--- a/Sources/Prefire/Preview/PrefireSnapshot.swift
+++ b/Sources/Prefire/Preview/PrefireSnapshot.swift
@@ -96,6 +96,9 @@ public struct DeviceConfig {
         
         window.isHidden = false
         window.rootViewController = hostingController
+        
+        hostingController.view.setNeedsLayout()
+        hostingController.view.layoutIfNeeded()
     }
 }
 #endif


### PR DESCRIPTION
### Short description 📝

In this PR, I have reintroduced setNeedsLayout and layoutIfNeeded which were removed in commit [80a880c](https://github.com/BarredEwe/Prefire/commit/80a880c60484c74014d6d13994f1ccf93b486edd).

These methods are necessary because onPreferenceChange is triggered by layoutIfNeeded.