### PR TITLE
Ungrouped Previews and Traits Parsing Improvement

### DIFF
--- a/Binaries/PrefireBinary.artifactbundle/info.json
+++ b/Binaries/PrefireBinary.artifactbundle/info.json
@@ -3,10 +3,10 @@
     "artifacts": {
         "PrefireBinary": {
             "type": "executable",
-            "version": "5.0.1",
+            "version": "5.0.2",
             "variants": [
                 {
-                    "path": "prefire-5.0.1-macos/bin/prefire",
+                    "path": "prefire-5.0.2-macos/bin/prefire",
                     "supportedTriples": ["x86_64-apple-macosx", "arm64-apple-macosx"]
                 },
             ]

--- a/Configuration.md
+++ b/Configuration.md
@@ -53,7 +53,6 @@ playbook_configuration:
 | `sources`                 | List of Swift files or folders to scan for previews. Defaults to inferred from the target                                                        |
 | `imports`                 | Extra imports added to the generated test or playbook file                                                                                      |
 | `testable_imports`        | Extra `@testable` imports added to allow test visibility                                                                                        |
-| `PREFIRE_CONFIGURATION_DIR` | **Points to the directory containing `.prefire.yml`.** <br> <br> Build tool plugins (such as Xcode and SwiftPM plugins) do **not** inherit shell environment variables set in your shell profile (e.g. `.zshrc`, `.bashrc`). <br> For reliable usage, set this environment variable using Xcode Build Settings, `.xcconfig` files, Scheme Environment Variables, inline with `xcodebuild`, or via Tuist target environment settings. |
 
 ---
 

--- a/Configuration.md
+++ b/Configuration.md
@@ -13,6 +13,7 @@ test_configuration:
   simulator_device: "iPhone15,2"
   required_os: 16
   preview_default_enabled: true
+  use_grouped_snapshots: true
   sources:
     - ${PROJECT_DIR}/Sources/
   snapshot_devices:
@@ -40,17 +41,19 @@ playbook_configuration:
 
 | Key                       | Description                                                                                                                                      |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `target`                  | Target name used for snapshot generation.Default: *FirstTarget*                                                                                  |
-| `test_target_path`        | Path to unit test directory. Snapshots will be written to its `__Snapshots__` folder.Default: target name folder                                 |
-| `test_file_path`          | Output file path for generated tests.Default: DerivedData or resolved via plugin                                                                 |
-| `template_file_path`      | Custom template path relative to target. Optional.Defaults:‣ *PreviewTests.stencil* for test plugin‣ *PreviewModels.stencil* for playbook plugin |
-| `simulator_device`        | Device identifier used to run tests (e.g. `iPhone15,2`). Optional                                                                                |
-| `required_os`             | Minimal iOS version required for preview rendering. Optional                                                                                     |
-| `snapshot_devices`        | List of logical snapshot "targets" (used as trait collections).Each will snapshot separately. Optional                                           |
-| `preview_default_enabled` | Should all detected previews be included by default?Set `false` if you want to require `.prefireEnabled()` manually.Default: `true`              |
-| `sources`                 | List of Swift files or folders to scan for previews.Defaults to inferred from the target                                                         |
-| `imports`                 | Extra imports added to the generated test or playbook file                                                                                       |
-| `testable_imports`        | Extra `@testable` imports added to allow test visibility                                                                                         |
+| `target`                  | Target name used for snapshot generation. Default: *FirstTarget*                                                                                 |
+| `test_target_path`        | Path to unit test directory. Snapshots will be written to its `__Snapshots__` folder. Default: target name folder                                |
+| `test_file_path`          | Output file path for generated tests. Default: DerivedData or resolved via plugin                                                                |
+| `template_file_path`      | Custom template path relative to target. Optional. Defaults:‣ *PreviewTests.stencil* for test plugin‣ *PreviewModels.stencil* for playbook plugin|
+| `simulator_device`        | Device identifier used to run tests (e.g. `iPhone15,2`). Optional                                                                               |
+| `required_os`             | Minimal iOS version required for preview rendering. Optional                                                                                    |
+| `snapshot_devices`        | List of logical snapshot "targets" (used as trait collections). Each will snapshot separately. Optional                                         |
+| `preview_default_enabled` | Should all detected previews be included by default? Set `false` if you want to require `.prefireEnabled()` manually. Default: `true`           |
+| `use_grouped_snapshots`   | Generate a single test file with all previews (`true`) or separate test files per source file (`false`). When `false`, use `{PREVIEW_FILE_NAME}` placeholder in `test_file_path`. Default: `true` |
+| `sources`                 | List of Swift files or folders to scan for previews. Defaults to inferred from the target                                                        |
+| `imports`                 | Extra imports added to the generated test or playbook file                                                                                      |
+| `testable_imports`        | Extra `@testable` imports added to allow test visibility                                                                                        |
+| `PREFIRE_CONFIGURATION_DIR` | **Points to the directory containing `.prefire.yml`.** <br> <br> Build tool plugins (such as Xcode and SwiftPM plugins) do **not** inherit shell environment variables set in your shell profile (e.g. `.zshrc`, `.bashrc`). <br> For reliable usage, set this environment variable using Xcode Build Settings, `.xcconfig` files, Scheme Environment Variables, inline with `xcodebuild`, or via Tuist target environment settings. |
 
 ---
 

--- a/Example/.prefire.yml
+++ b/Example/.prefire.yml
@@ -8,6 +8,7 @@ test_configuration:
   - imports:
       - UIKit
       - Foundation
+  - use_grouped_snapshots: false
 
 playbook_configuration:
   - imports:

--- a/Example/PrefireExampleTests/PrefireExampleTests.swift
+++ b/Example/PrefireExampleTests/PrefireExampleTests.swift
@@ -3,6 +3,6 @@ import Prefire
 
 // MARK: - Generated Tests
 
-let tests = _TestFile.self
+private let tests = _TestFile.self
 
 private struct _TestFile { }

--- a/Example/PrefireExampleTests/PrefireExampleTests.swift
+++ b/Example/PrefireExampleTests/PrefireExampleTests.swift
@@ -3,4 +3,6 @@ import Prefire
 
 // MARK: - Generated Tests
 
-let tests = PreviewTests.self
+let tests = _TestFile.self
+
+private struct _TestFile { }

--- a/Plugins/PrefireTestsPlugin/TestedTargetFinder.swift
+++ b/Plugins/PrefireTestsPlugin/TestedTargetFinder.swift
@@ -39,7 +39,7 @@ enum TestedTargetFinder {
         let possibleConfigPaths = [
             targetDirectory.appending("/\(targetName)"),
             targetDirectory
-        ].compactMap { $0 }
+        ]
 
         for configPath in possibleConfigPaths {
             guard let configUrl = URL(string: "file://\(configPath)/.prefire.yml"),

--- a/Plugins/PrefireTestsPlugin/TestedTargetFinder.swift
+++ b/Plugins/PrefireTestsPlugin/TestedTargetFinder.swift
@@ -38,8 +38,13 @@ enum TestedTargetFinder {
     private static func loadTargetNameFromConfig(for targetDirectory: String, targetName: String) -> String? {
         let possibleConfigPaths = [
             targetDirectory.appending("/\(targetName)"),
-            targetDirectory
-        ]
+            targetDirectory,
+
+            // We shouldn't just considerer the target directory for config file.
+            // When running into complex mudularized projects, you might have a shared settings folder
+            // for all your targets.
+            ProcessInfo.processInfo.environment["PREFIRE_CONFIGURATION_DIR"]
+        ].compactMap { $0 }
 
         for configPath in possibleConfigPaths {
             guard let configUrl = URL(string: "file://\(configPath)/.prefire.yml"),

--- a/Plugins/PrefireTestsPlugin/TestedTargetFinder.swift
+++ b/Plugins/PrefireTestsPlugin/TestedTargetFinder.swift
@@ -38,12 +38,7 @@ enum TestedTargetFinder {
     private static func loadTargetNameFromConfig(for targetDirectory: String, targetName: String) -> String? {
         let possibleConfigPaths = [
             targetDirectory.appending("/\(targetName)"),
-            targetDirectory,
-
-            // We shouldn't just considerer the target directory for config file.
-            // When running into complex mudularized projects, you might have a shared settings folder
-            // for all your targets.
-            ProcessInfo.processInfo.environment["PREFIRE_CONFIGURATION_DIR"]
+            targetDirectory
         ].compactMap { $0 }
 
         for configPath in possibleConfigPaths {

--- a/PrefireExecutable/Sources/PrefireCore/PrefireGenerator.swift
+++ b/PrefireExecutable/Sources/PrefireCore/PrefireGenerator.swift
@@ -89,7 +89,11 @@ public enum PrefireGenerator {
             // Generate one file with all previews
             var arguments = arguments
             arguments["previewsMacrosDict"] = previewModels as NSArray
-            try renderAndWrite(parserResult: parserResult, inlineTemplate: inlineTemplate, output: output, arguments: arguments)
+            
+            // For grouped snapshots, replace {PREVIEW_FILE_NAME} with "Preview" to maintain current class name
+            let customizedTemplate = inlineTemplate.replacingOccurrences(of: "{PREVIEW_FILE_NAME}", with: "Preview")
+            
+            try renderAndWrite(parserResult: parserResult, inlineTemplate: customizedTemplate, output: output, arguments: arguments)
         } else {
             // Generate one file per source file containing previews
             try generateUngroupedFiles(

--- a/PrefireExecutable/Sources/PrefireCore/PrefireGenerator.swift
+++ b/PrefireExecutable/Sources/PrefireCore/PrefireGenerator.swift
@@ -14,7 +14,8 @@ public enum PrefireGenerator {
         arguments: [String: NSObject],
         inlineTemplate: String,
         defaultEnabled: Bool,
-        cacheDir: Path? = nil
+        cacheDir: Path? = nil,
+        useGroupedSnapshots: Bool
     ) async throws {
         startTime = Date()
 
@@ -33,6 +34,9 @@ public enum PrefireGenerator {
         }
 
         let fileContents: [(Path, String)] = try swiftFiles.map { ($0, try $0.read(.utf8)) }
+
+        // If use grouped is false, we geneate one file per tests
+        // and use the template as output replacing the "{PREVIEW_FILE_NAME}" with the name of the file
 
         let manager = PrefireCacheManager(version: version, cacheBasePath: cacheDir)
         let (types, previews) = try await manager.loadOrGenerate(
@@ -71,17 +75,88 @@ public enum PrefireGenerator {
 
         let previewModels = previews
             .sorted { $0.key > $1.key }
-            .compactMap { RawPreviewModel(from: $0.value, filename: $0.key) }
-            .map { $0.makeStencilDict() }
-
-        var arguments = arguments
-        arguments["previewsMacrosDict"] = previewModels as NSArray
+            .compactMap { entry -> [String: Any?]? in
+                guard let model = RawPreviewModel(from: entry.value, filename: entry.key) else { return nil }
+                var dict = model.makeStencilDict()
+                // Add the source filename for ungrouped generation
+                dict["sourceFileName"] = extractFileNameFromKey(entry.key)
+                return dict
+            }
 
         let parserResult = FileParserResult(path: nil, module: nil, types: types.types, functions: [], typealiases: [])
-
-        try renderAndWrite(parserResult: parserResult, inlineTemplate: inlineTemplate, output: output, arguments: arguments)
+        
+        if useGroupedSnapshots {
+            // Generate one file with all previews
+            var arguments = arguments
+            arguments["previewsMacrosDict"] = previewModels as NSArray
+            try renderAndWrite(parserResult: parserResult, inlineTemplate: inlineTemplate, output: output, arguments: arguments)
+        } else {
+            // Generate one file per source file containing previews
+            try generateUngroupedFiles(
+                previewModels: previewModels,
+                parserResult: parserResult,
+                inlineTemplate: inlineTemplate,
+                output: output,
+                arguments: arguments
+            )
+        }
 
         Logger.info("✅ Generation completed in \(startTime.distance(to: Date()).formatted())")
+    }
+    
+    private static func generateUngroupedFiles(
+        previewModels: [[String: Any?]],
+        parserResult: FileParserResult,
+        inlineTemplate: String,
+        output: Path,
+        arguments: [String: NSObject]
+    ) throws {
+        // Group preview models by their source file name
+        let groupedByFile = Dictionary(grouping: previewModels) { previewModel -> String in
+            return previewModel["sourceFileName"] as? String ?? "Unknown"
+        }
+        
+        Logger.info("📝 Generating \(groupedByFile.count) separate test files...")
+        
+        for (fileName, models) in groupedByFile {
+            guard fileName != "Unknown" else { continue }
+            
+            // Replace the placeholder in the output path
+            let outputPath = replacePreviewFileName(in: output, with: fileName)
+            
+            var fileArguments = arguments
+            fileArguments["previewsMacrosDict"] = models as NSArray
+            
+            // Replace the placeholder in the template as well
+            let customizedTemplate = inlineTemplate.replacingOccurrences(of: "{PREVIEW_FILE_NAME}", with: fileName)
+            
+            Logger.info("🖋 Rendering template for \(fileName)...")
+            try renderAndWrite(
+                parserResult: parserResult,
+                inlineTemplate: customizedTemplate,
+                output: outputPath,
+                arguments: fileArguments
+            )
+        }
+    }
+    
+    private static func extractFileNameFromKey(_ key: String) -> String {
+        // Key format is "FileName_index", extract just the file name part
+        let components = key.components(separatedBy: "_")
+        guard !components.isEmpty else { return key }
+        
+        // If the last component is a number, it's likely an index
+        if components.count > 1 && Int(components.last!) != nil {
+            return components.dropLast().joined(separator: "_")
+        }
+        
+        return key
+    }
+    
+    private static func replacePreviewFileName(in path: Path, with fileName: String) -> Path {
+        let pathString = path.string
+        let updatedPath = pathString.replacingOccurrences(of: "{PREVIEW_FILE_NAME}", with: fileName)
+        return Path(updatedPath)
     }
 
     private static func renderAndWrite(

--- a/PrefireExecutable/Sources/PrefireCore/Templates/PreviewTestsTemplate.swift
+++ b/PrefireExecutable/Sources/PrefireCore/Templates/PreviewTestsTemplate.swift
@@ -20,7 +20,7 @@ import SnapshotTesting
     import AccessibilitySnapshot
 #endif
 
-@MainActor class PreviewTests: XCTestCase, Sendable {
+@MainActor class {PREVIEW_FILE_NAME}Tests: XCTestCase, Sendable {
     private var simulatorDevice: String?{% if argument.simulatorDevice %} = "{{ argument.simulatorDevice|default:nil }}"{% endif %}
     private var requiredOSVersion: Int?{% if argument.simulatorOSVersion %} = {{ argument.simulatorOSVersion }}{% endif %}
     private let snapshotDevices: [String]{% if argument.snapshotDevices %} = {{ argument.snapshotDevices|split:"|" }}{% else %} = []{% endif %}
@@ -172,11 +172,11 @@ import SnapshotTesting
 
 // MARK: - SnapshotTesting + Extensions
 
-extension DeviceConfig {
+private extension DeviceConfig {
     var imageConfig: ViewImageConfig { ViewImageConfig(safeArea: safeArea, size: size, traits: traits) }
 }
 
-extension ViewImageConfig {
+private extension ViewImageConfig {
     var deviceConfig: DeviceConfig { DeviceConfig(safeArea: safeArea, size: size, traits: traits) }
 }
 

--- a/PrefireExecutable/Sources/prefire/Commands/Playbook/GeneratePlaybookCommand.swift
+++ b/PrefireExecutable/Sources/prefire/Commands/Playbook/GeneratePlaybookCommand.swift
@@ -52,7 +52,8 @@ enum GeneratePlaybookCommand {
             arguments: await makeArguments(for: options),
             inlineTemplate: try options.template?.read(.utf8) ?? EmbeddedTemplates.previewModels,
             defaultEnabled: options.previewDefaultEnabled,
-            cacheDir: options.cacheBasePath
+            cacheDir: options.cacheBasePath,
+            useGroupedSnapshots: true // Playbooks are always grouped
         )
     }
 

--- a/PrefireExecutable/Sources/prefire/Commands/Tests/GenerateTestsCommand.swift
+++ b/PrefireExecutable/Sources/prefire/Commands/Tests/GenerateTestsCommand.swift
@@ -4,7 +4,7 @@ import PathKit
 
 private enum Constants {
     static let snapshotFileName = "PreviewTests.generated.swift"
-    static let spapshotFileTemplated = "{PREVIEW_FILE_NAME}Tests.generated.swift"
+    static let snapshotFileTemplated = "{PREVIEW_FILE_NAME}Tests.generated.swift"
 }
 
 struct GeneratedTestsOptions {
@@ -83,7 +83,7 @@ enum GenerateTestsCommand {
         try await PrefireGenerator.generate(
             version: Prefire.Version.value,
             sources: options.sources,
-            output: options.output + (options.useGroupedSnapshots ? Constants.snapshotFileName : Constants.spapshotFileTemplated),
+            output: options.output + (options.useGroupedSnapshots ? Constants.snapshotFileName : Constants.snapshotFileTemplated),
             arguments: await GenerateTestsCommand.makeArguments(for: options),
             inlineTemplate: try options.template?.read(.utf8) ?? EmbeddedTemplates.previewTests,
             defaultEnabled: options.prefireEnabledMarker,

--- a/PrefireExecutable/Sources/prefire/Commands/Tests/GenerateTestsCommand.swift
+++ b/PrefireExecutable/Sources/prefire/Commands/Tests/GenerateTestsCommand.swift
@@ -4,6 +4,7 @@ import PathKit
 
 private enum Constants {
     static let snapshotFileName = "PreviewTests.generated.swift"
+    static let spapshotFileTemplated = "{PREVIEW_FILE_NAME}Tests.generated.swift"
 }
 
 struct GeneratedTestsOptions {
@@ -20,6 +21,7 @@ struct GeneratedTestsOptions {
     var snapshotDevices: [String]?
     var imports: [String]?
     var testableImports: [String]?
+    var useGroupedSnapshots: Bool
 
     init(
         target: String?,
@@ -51,6 +53,7 @@ struct GeneratedTestsOptions {
         self.cacheBasePath = cacheBasePath.flatMap({ Path($0) })
         self.device = config?.tests.device ?? device
         self.osVersion = config?.tests.osVersion ?? osVersion
+        useGroupedSnapshots = config?.tests.useGroupedSnapshots ?? true
         snapshotDevices = config?.tests.snapshotDevices
         imports = config?.tests.imports
         testableImports = config?.tests.testableImports
@@ -80,11 +83,12 @@ enum GenerateTestsCommand {
         try await PrefireGenerator.generate(
             version: Prefire.Version.value,
             sources: options.sources,
-            output: options.output + Constants.snapshotFileName,
+            output: options.output + (options.useGroupedSnapshots ? Constants.snapshotFileName : Constants.spapshotFileTemplated),
             arguments: await GenerateTestsCommand.makeArguments(for: options),
             inlineTemplate: try options.template?.read(.utf8) ?? EmbeddedTemplates.previewTests,
             defaultEnabled: options.prefireEnabledMarker,
-            cacheDir: options.cacheBasePath
+            cacheDir: options.cacheBasePath,
+            useGroupedSnapshots: options.useGroupedSnapshots
         )
     }
 
@@ -110,7 +114,7 @@ enum GenerateTestsCommand {
             Keys.imports: options.imports as? NSArray,
             Keys.testableImports: options.testableImports as? NSArray,
             Keys.mainTarget: options.target as? NSString,
-            Keys.file: snapshotOutput?.string as? NSString
+            Keys.file: snapshotOutput?.string as? NSString,
         ].filter({ $0.value != nil }) as? [String: NSObject] ?? [:]
     }
 }

--- a/PrefireExecutable/Sources/prefire/Commands/Version/Version.swift
+++ b/PrefireExecutable/Sources/prefire/Commands/Version/Version.swift
@@ -5,7 +5,7 @@ extension Prefire {
     struct Version: ParsableCommand {
         static let configuration = CommandConfiguration(abstract: "Display the current version of Prefire")
 
-        static let value: String = "5.0.1"
+        static let value: String = "5.0.2"
 
         func run() throws {
             print(Self.value)

--- a/PrefireExecutable/Sources/prefire/Config/Config.swift
+++ b/PrefireExecutable/Sources/prefire/Config/Config.swift
@@ -23,6 +23,7 @@ struct TestsConfig {
     var previewDefaultEnabled: Bool?
     var imports: [String]?
     var testableImports: [String]?
+    var useGroupedSnapshots: Bool?
 
     enum CodingKeys: String, CodingKey {
         case target = "target"
@@ -36,6 +37,7 @@ struct TestsConfig {
         case previewDefaultEnabled = "preview_default_enabled"
         case imports = "imports"
         case testableImports = "testable_imports"
+        case useGroupedSnapshots = "use_grouped_snapshots"
     }
 }
 

--- a/PrefireExecutable/Sources/prefire/Config/ConfigDecoder.swift
+++ b/PrefireExecutable/Sources/prefire/Config/ConfigDecoder.swift
@@ -70,6 +70,8 @@ final class ConfigDecoder {
             config.tests.testableImports = getValues(from: components, lines: lines, env: env)
         case .testTargetPath:
             config.tests.testTargetPath = getValue(from: components.last, env: env)
+        case .useGroupedSnapshots:
+            config.tests.useGroupedSnapshots = getValue(from: components.last, env: env) == "true"
         }
     }
 

--- a/PrefireExecutable/Tests/PrefireTests/PrefireGeneratorTests.swift
+++ b/PrefireExecutable/Tests/PrefireTests/PrefireGeneratorTests.swift
@@ -16,7 +16,8 @@ final class PrefireGeneratorTests: XCTestCase {
                 output: output,
                 arguments: args,
                 inlineTemplate: template,
-                defaultEnabled: true
+                defaultEnabled: true,
+                useGroupedSnapshots: true
             )
         } catch {
             XCTFail("Unexpected error thrown: \(error)")
@@ -37,12 +38,40 @@ final class PrefireGeneratorTests: XCTestCase {
             arguments: args,
             inlineTemplate: template,
             defaultEnabled: true,
-            cacheDir: cache
+            cacheDir: cache,
+            useGroupedSnapshots: true
         )
 
         let result = try output.read(.utf8)
 
         XCTAssertTrue(result.contains("TestPreview"), "Should include basic preview")
         XCTAssertFalse(result.contains("TestPreview_Ignored"), "Should skip explicitly ignored preview")
+    }
+    
+    func testUngroupedFileGeneration() async throws {
+        let file = Path(fixtureTestPreviewSource)
+        let outputTemplate = Path("/tmp/{PREVIEW_FILE_NAME}Tests.generated.swift")
+        let cache = Path("/tmp/cache/")
+        let template = "// File: {PREVIEW_FILE_NAME}\n{% for p in argument.previewsMacrosDict %}{{ p.componentTestName }}\n{% endfor %}"
+        let args: [String: NSObject] = [:]
+        
+        try await PrefireGenerator.generate(
+            version: "1.0.0",
+            sources: [file],
+            output: outputTemplate,
+            arguments: args,
+            inlineTemplate: template,
+            defaultEnabled: true,
+            cacheDir: cache,
+            useGroupedSnapshots: false // Test ungrouped generation
+        )
+
+        // Should generate file with name based on the fixture file
+        let expectedOutput = Path("/tmp/TestPreviewTests.generated.swift")
+        XCTAssertTrue(expectedOutput.exists, "Should generate file with replaced filename")
+        
+        let result = try expectedOutput.read(.utf8)
+        XCTAssertTrue(result.contains("// File: TestPreview"), "Should replace {PREVIEW_FILE_NAME} placeholder")
+        XCTAssertTrue(result.contains("TestPreview"), "Should include basic preview")
     }
 }

--- a/PrefireExecutable/Tests/PrefireTests/RawPreviewModelTests.swift
+++ b/PrefireExecutable/Tests/PrefireTests/RawPreviewModelTests.swift
@@ -15,7 +15,7 @@ class RawPreviewModelTests: XCTestCase {
         XCTAssertEqual(rawPreviewModel?.body, "    Text(\"TestView\")")
         XCTAssertEqual(rawPreviewModel?.properties, nil)
         XCTAssertEqual(rawPreviewModel?.displayName, "TestViewName")
-        XCTAssertEqual(rawPreviewModel?.traits, ".sizeThatFitsLayout")
+        XCTAssertEqual(rawPreviewModel?.traits, [".sizeThatFitsLayout"])
     }
 
     func test_initWithoutName() {
@@ -35,6 +35,111 @@ class RawPreviewModelTests: XCTestCase {
         XCTAssertEqual(rawPreviewModel?.body, "\n    VStack {\n        Text(name)\n    }\n    .snapshot(delay: 8)")
         XCTAssertEqual(rawPreviewModel?.properties, "    @State var name: String = \"TestView\"")
         XCTAssertEqual(rawPreviewModel?.displayName, "TestView")
-        XCTAssertEqual(rawPreviewModel?.traits, ".sizeThatFitsLayout")
+        XCTAssertEqual(rawPreviewModel?.traits, [".sizeThatFitsLayout"])
+    }
+    
+    func test_initWithMultipleTraits() {
+        let previewBodyWithMultipleTraits = """
+        #Preview("TestViewName", traits: .device, .sizeThatFitsLayout) {
+            Text("TestView")
+        }
+
+        """
+        let rawPreviewModel = RawPreviewModel(from: previewBodyWithMultipleTraits, filename: "Test")
+
+        XCTAssertEqual(rawPreviewModel?.body, "    Text(\"TestView\")")
+        XCTAssertEqual(rawPreviewModel?.properties, nil)
+        XCTAssertEqual(rawPreviewModel?.displayName, "TestViewName")
+        XCTAssertEqual(rawPreviewModel?.traits, [".device", ".sizeThatFitsLayout"])
+    }
+    
+    func test_initWithFunctionStyleTrait() {
+        let previewBodyWithFunctionTrait = """
+        #Preview("TestViewName", traits: .myTrait("one", 2)) {
+            Text("TestView")
+        }
+
+        """
+        let rawPreviewModel = RawPreviewModel(from: previewBodyWithFunctionTrait, filename: "Test")
+
+        XCTAssertEqual(rawPreviewModel?.body, "    Text(\"TestView\")")
+        XCTAssertEqual(rawPreviewModel?.properties, nil)
+        XCTAssertEqual(rawPreviewModel?.displayName, "TestViewName")
+        XCTAssertEqual(rawPreviewModel?.traits, [".myTrait(\"one\", 2)"])
+    }
+    
+    func test_initWithMixedTraits() {
+        let previewBodyWithMixedTraits = """
+        #Preview("TestViewName", traits: .device, .myTrait("test"), .sizeThatFitsLayout) {
+            Text("TestView")
+        }
+
+        """
+        let rawPreviewModel = RawPreviewModel(from: previewBodyWithMixedTraits, filename: "Test")
+
+        XCTAssertEqual(rawPreviewModel?.body, "    Text(\"TestView\")")
+        XCTAssertEqual(rawPreviewModel?.properties, nil)
+        XCTAssertEqual(rawPreviewModel?.displayName, "TestViewName")
+        XCTAssertEqual(rawPreviewModel?.traits, [".device", ".myTrait(\"test\")", ".sizeThatFitsLayout"])
+    }
+    
+    func test_initWithoutTraits() {
+        let previewBodyWithoutTraits = """
+        #Preview("TestViewName") {
+            Text("TestView")
+        }
+
+        """
+        let rawPreviewModel = RawPreviewModel(from: previewBodyWithoutTraits, filename: "Test")
+
+        XCTAssertEqual(rawPreviewModel?.body, "    Text(\"TestView\")")
+        XCTAssertEqual(rawPreviewModel?.properties, nil)
+        XCTAssertEqual(rawPreviewModel?.displayName, "TestViewName")
+        XCTAssertEqual(rawPreviewModel?.traits, [".device"]) // Should default to .device
+    }
+    
+    func test_initWithMultipleFunctionStyleTraits() {
+        let previewBodyWithMultipleFunctionTraits = """
+        #Preview("TestViewName", traits: .myTrait("param1", 123), .anotherTrait("hello", "world")) {
+            Text("TestView")
+        }
+
+        """
+        let rawPreviewModel = RawPreviewModel(from: previewBodyWithMultipleFunctionTraits, filename: "Test")
+
+        XCTAssertEqual(rawPreviewModel?.body, "    Text(\"TestView\")")
+        XCTAssertEqual(rawPreviewModel?.properties, nil)
+        XCTAssertEqual(rawPreviewModel?.displayName, "TestViewName")
+        XCTAssertEqual(rawPreviewModel?.traits, [".myTrait(\"param1\", 123)", ".anotherTrait(\"hello\", \"world\")"])
+    }
+    
+    func test_initWithComplexMixedTraits() {
+        let previewBodyWithComplexTraits = """
+        #Preview("TestViewName", traits: .device, .myTrait("test", 42), .sizeThatFitsLayout, .customFunc(true, "value")) {
+            Text("TestView")
+        }
+
+        """
+        let rawPreviewModel = RawPreviewModel(from: previewBodyWithComplexTraits, filename: "Test")
+
+        XCTAssertEqual(rawPreviewModel?.body, "    Text(\"TestView\")")
+        XCTAssertEqual(rawPreviewModel?.properties, nil)
+        XCTAssertEqual(rawPreviewModel?.displayName, "TestViewName")
+        XCTAssertEqual(rawPreviewModel?.traits, [".device", ".myTrait(\"test\", 42)", ".sizeThatFitsLayout", ".customFunc(true, \"value\")"])
+    }
+    
+    func test_initWithNestedParenthesesInTraits() {
+        let previewBodyWithNestedParentheses = """
+        #Preview("TestViewName", traits: .complexTrait(nested("inner", value), other(1, 2)), .device) {
+            Text("TestView")
+        }
+
+        """
+        let rawPreviewModel = RawPreviewModel(from: previewBodyWithNestedParentheses, filename: "Test")
+
+        XCTAssertEqual(rawPreviewModel?.body, "    Text(\"TestView\")")
+        XCTAssertEqual(rawPreviewModel?.properties, nil)
+        XCTAssertEqual(rawPreviewModel?.displayName, "TestViewName")
+        XCTAssertEqual(rawPreviewModel?.traits, [".complexTrait(nested(\"inner\", value), other(1, 2))", ".device"])
     }
 }

--- a/PrefireExecutable/Tests/PrefireTests/TestedTargetFinderTests.swift
+++ b/PrefireExecutable/Tests/PrefireTests/TestedTargetFinderTests.swift
@@ -1,0 +1,140 @@
+import Foundation
+import XCTest
+
+final class TestedTargetFinderTests: XCTestCase {
+    private let testConfigString = """
+    test_configuration:
+      target: MyTestTarget
+      test_target_path: /path/to/tests
+    """
+    
+    private var tempDirectory: URL!
+    private var configFile: URL!
+    
+    override func setUp() {
+        super.setUp()
+        // Create a temporary directory for testing
+        tempDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try! FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        
+        // Create a test .prefire.yml file
+        configFile = tempDirectory.appendingPathComponent(".prefire.yml")
+        try! testConfigString.write(to: configFile, atomically: true, encoding: .utf8)
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        // Clean up temporary directory
+        try? FileManager.default.removeItem(at: tempDirectory)
+    }
+    
+    func test_loadTargetNameFromConfigWithPrefireConfigurationDir() {
+        // Save original environment
+        let originalEnv = ProcessInfo.processInfo.environment["PREFIRE_CONFIGURATION_DIR"]
+        
+        // Set PREFIRE_CONFIGURATION_DIR environment variable
+        setenv("PREFIRE_CONFIGURATION_DIR", tempDirectory.path, 1)
+        
+        // Test that the target name is correctly loaded from config
+        let targetName = loadTargetNameFromConfig(
+            for: "/some/other/directory", 
+            targetName: "SomeTests"
+        )
+        
+        XCTAssertEqual(targetName, "MyTestTarget", "Should load target name from config in PREFIRE_CONFIGURATION_DIR")
+        
+        // Restore original environment
+        if let originalEnv = originalEnv {
+            setenv("PREFIRE_CONFIGURATION_DIR", originalEnv, 1)
+        } else {
+            unsetenv("PREFIRE_CONFIGURATION_DIR")
+        }
+    }
+    
+    func test_loadTargetNameFromConfigWithoutPrefireConfigurationDir() {
+        // Ensure PREFIRE_CONFIGURATION_DIR is not set
+        unsetenv("PREFIRE_CONFIGURATION_DIR")
+        
+        // Test that it falls back to other search paths
+        let targetName = loadTargetNameFromConfig(
+            for: "/some/directory", 
+            targetName: "SomeTests"
+        )
+        
+        XCTAssertNil(targetName, "Should return nil when no config is found in standard paths")
+    }
+    
+    func test_loadTargetNameFromConfigWithInvalidPrefireConfigurationDir() {
+        // Set PREFIRE_CONFIGURATION_DIR to a non-existent path
+        setenv("PREFIRE_CONFIGURATION_DIR", "/non/existent/path", 1)
+        
+        let targetName = loadTargetNameFromConfig(
+            for: "/some/directory", 
+            targetName: "SomeTests"
+        )
+        
+        XCTAssertNil(targetName, "Should return nil when PREFIRE_CONFIGURATION_DIR points to invalid path")
+        
+        // Clean up
+        unsetenv("PREFIRE_CONFIGURATION_DIR")
+    }
+    
+    func test_loadTargetNameFromConfigPrecedence() {
+        // Create config file in target directory
+        let targetDirectory = tempDirectory.appendingPathComponent("target")
+        try! FileManager.default.createDirectory(at: targetDirectory, withIntermediateDirectories: true)
+        
+        let targetConfigFile = targetDirectory.appendingPathComponent(".prefire.yml")
+        let targetConfigString = """
+        test_configuration:
+          target: TargetDirTarget
+        """
+        try! targetConfigString.write(to: targetConfigFile, atomically: true, encoding: .utf8)
+        
+        // Set PREFIRE_CONFIGURATION_DIR to a different directory with different target
+        setenv("PREFIRE_CONFIGURATION_DIR", tempDirectory.path, 1)
+        
+        // Test that target directory takes precedence over PREFIRE_CONFIGURATION_DIR
+        let targetName = loadTargetNameFromConfig(
+            for: targetDirectory.path, 
+            targetName: "SomeTests"
+        )
+        
+        XCTAssertEqual(targetName, "TargetDirTarget", "Target directory config should take precedence over PREFIRE_CONFIGURATION_DIR")
+        
+        // Clean up
+        unsetenv("PREFIRE_CONFIGURATION_DIR")
+    }
+    
+    // MARK: - Helper method extracted from TestedTargetFinder
+    
+    /// Easy loading of testTarget from a configuration file `.prefire.yml`
+    /// - Parameters:
+    ///   - targetDirectory: Test target directory
+    ///   - targetName: Test target name
+    /// - Returns: Target loaded from configuration file
+    private func loadTargetNameFromConfig(for targetDirectory: String, targetName: String) -> String? {
+        let possibleConfigPaths = [
+            targetDirectory.appending("/\(targetName)"),
+            targetDirectory,
+            
+            // We shouldn't just consider the target directory for config file.
+            // When running into complex modularized projects, you might have a shared settings folder
+            // for all your targets.
+            ProcessInfo.processInfo.environment["PREFIRE_CONFIGURATION_DIR"]
+        ].compactMap { $0 }
+        
+        for configPath in possibleConfigPaths {
+            guard let configUrl = URL(string: "file://\(configPath)/.prefire.yml"),
+                  FileManager.default.fileExists(atPath: configUrl.path) else { continue }
+            
+            let configDataString = try? String(contentsOf: configUrl, encoding: .utf8).components(separatedBy: .newlines)
+            
+            if let targetName = configDataString?.first(where: { $0.contains("target:") })?.components(separatedBy: ":").last {
+                return targetName.trimmingCharacters(in: .whitespaces)
+            }
+        }
+        
+        return nil
+    }
+}

--- a/PrefireExecutable/Tests/PrefireTests/TestedTargetFinderTests.swift
+++ b/PrefireExecutable/Tests/PrefireTests/TestedTargetFinderTests.swift
@@ -28,55 +28,14 @@ final class TestedTargetFinderTests: XCTestCase {
         try? FileManager.default.removeItem(at: tempDirectory)
     }
     
-    func test_loadTargetNameFromConfigWithPrefireConfigurationDir() {
-        // Save original environment
-        let originalEnv = ProcessInfo.processInfo.environment["PREFIRE_CONFIGURATION_DIR"]
-        
-        // Set PREFIRE_CONFIGURATION_DIR environment variable
-        setenv("PREFIRE_CONFIGURATION_DIR", tempDirectory.path, 1)
-        
-        // Test that the target name is correctly loaded from config
-        let targetName = loadTargetNameFromConfig(
-            for: "/some/other/directory", 
-            targetName: "SomeTests"
-        )
-        
-        XCTAssertEqual(targetName, "MyTestTarget", "Should load target name from config in PREFIRE_CONFIGURATION_DIR")
-        
-        // Restore original environment
-        if let originalEnv = originalEnv {
-            setenv("PREFIRE_CONFIGURATION_DIR", originalEnv, 1)
-        } else {
-            unsetenv("PREFIRE_CONFIGURATION_DIR")
-        }
-    }
-    
-    func test_loadTargetNameFromConfigWithoutPrefireConfigurationDir() {
-        // Ensure PREFIRE_CONFIGURATION_DIR is not set
-        unsetenv("PREFIRE_CONFIGURATION_DIR")
-        
-        // Test that it falls back to other search paths
+    func test_loadTargetNameFromConfigWithoutConfig() {
+        // Test that it returns nil when no config is found
         let targetName = loadTargetNameFromConfig(
             for: "/some/directory", 
             targetName: "SomeTests"
         )
         
         XCTAssertNil(targetName, "Should return nil when no config is found in standard paths")
-    }
-    
-    func test_loadTargetNameFromConfigWithInvalidPrefireConfigurationDir() {
-        // Set PREFIRE_CONFIGURATION_DIR to a non-existent path
-        setenv("PREFIRE_CONFIGURATION_DIR", "/non/existent/path", 1)
-        
-        let targetName = loadTargetNameFromConfig(
-            for: "/some/directory", 
-            targetName: "SomeTests"
-        )
-        
-        XCTAssertNil(targetName, "Should return nil when PREFIRE_CONFIGURATION_DIR points to invalid path")
-        
-        // Clean up
-        unsetenv("PREFIRE_CONFIGURATION_DIR")
     }
     
     func test_loadTargetNameFromConfigPrecedence() {
@@ -91,19 +50,13 @@ final class TestedTargetFinderTests: XCTestCase {
         """
         try! targetConfigString.write(to: targetConfigFile, atomically: true, encoding: .utf8)
         
-        // Set PREFIRE_CONFIGURATION_DIR to a different directory with different target
-        setenv("PREFIRE_CONFIGURATION_DIR", tempDirectory.path, 1)
-        
-        // Test that target directory takes precedence over PREFIRE_CONFIGURATION_DIR
+        // Test that target directory config is found
         let targetName = loadTargetNameFromConfig(
             for: targetDirectory.path, 
             targetName: "SomeTests"
         )
         
-        XCTAssertEqual(targetName, "TargetDirTarget", "Target directory config should take precedence over PREFIRE_CONFIGURATION_DIR")
-        
-        // Clean up
-        unsetenv("PREFIRE_CONFIGURATION_DIR")
+        XCTAssertEqual(targetName, "TargetDirTarget", "Should find config in target directory")
     }
     
     // MARK: - Helper method extracted from TestedTargetFinder
@@ -116,12 +69,7 @@ final class TestedTargetFinderTests: XCTestCase {
     private func loadTargetNameFromConfig(for targetDirectory: String, targetName: String) -> String? {
         let possibleConfigPaths = [
             targetDirectory.appending("/\(targetName)"),
-            targetDirectory,
-            
-            // We shouldn't just consider the target directory for config file.
-            // When running into complex modularized projects, you might have a shared settings folder
-            // for all your targets.
-            ProcessInfo.processInfo.environment["PREFIRE_CONFIGURATION_DIR"]
+            targetDirectory
         ].compactMap { $0 }
         
         for configPath in possibleConfigPaths {


### PR DESCRIPTION
# Add Support for Ungrouped Test File Generation

## Summary

This PR introduces the ability to generate separate test files for each source file containing previews, instead of one monolithic test file. This enhancement provides better organization and cleaner test structure for projects with many preview files.

## Key Features

### Ungrouped File Generation
- Generate individual test files per source file (e.g., `ButtonTests.generated.swift`, `CardTests.generated.swift`)
- Template placeholder support using `{PREVIEW_FILE_NAME}` in file paths
- New `use_grouped_snapshots ` configuration option to toggle between modes
- Backward compatible: defaults to `true` (existing grouped behavior)

### Enhanced Traits Parsing
- Robust parsing for complex trait syntax including function calls with parameters
- Support for mixed comma-separated traits with proper parentheses balancing
- Handles nested functions and quoted parameters correctly
- Examples: `.device`, `.myTrait("param", 123)`

### Configuration
```yaml
test_configuration:
  use_grouped_snapshots: false  # Enable ungrouped mode
  test_file_path: "Tests/{PREVIEW_FILE_NAME}Tests.generated.swift"
```

## Traits Integration in Stencil Templates

The enhanced traits parsing now provides richer data to Stencil templates through the `previewsMacrosDict` argument. Each preview model contains a `traits` array that can be used in templates:

```stencil
{% for preview in argument.previewsMacrosDict %}
    func test_{{ preview.componentTestName }}_Preview() {
        let content = {
            {{ preview.body }}
        }
        
        // Traits are now available as an array
        {% for trait in preview.traits %}
        // Individual trait: {{ trait }}
        {% endfor %}
        
        // Example usage in snapshot testing
        assertSnapshot(
            matching: content(),
            as: .image(
                {% if preview.traits contains ".sizeThatFitsLayout" %}
                layout: .sizeThatFits
                {% else %}
                layout: .device(config: .iPhone13)
                {% endif %}
            )
        )
    }
{% endfor %}
```

Previously, traits were stored as a single string. Now they are parsed into individual components and made available as an array, allowing templates to:
- Iterate over individual traits
- Check for specific traits using conditional logic
- Apply different snapshot configurations based on trait presence
- Handle complex trait parameters for custom behavior

## Backward Compatibility

- Default behavior unchanged: `use_grouped_snapshots` defaults to `true`
- All existing configurations and APIs continue to work
- Playbook generation remains grouped (no breaking changes)
- Smooth migration path for projects wanting to adopt ungrouped mode
- Templates can still access traits data in both old and new formats

## Preview

<img width="429" height="880" alt="Screenshot 2025-08-24 at 17 59 16" src="https://github.com/user-attachments/assets/473d9e2c-4374-40fe-a77a-85361d8f8be9" />

> [!NOTE]
> Claude code was used to help with the traits parsing logic validate the tests.