### PR TITLE
Mint supporting

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -30,6 +30,24 @@ jobs:
         
       - name: Build Prefire
         run: make build
-        
+
       - name: Run PrefireExecutable Tests
         run: make test
+
+      - name: Build prefire CLI wrapper
+        run: swift build -c release --product prefire
+
+      - name: Smoke test prefire CLI wrapper
+        run: |
+          set -euo pipefail
+          bin=$(pwd)/.build/release/prefire
+          $bin --version
+          $bin --help | grep -q "Generate Playbook"
+          cd /tmp && $bin --version
+          output=$(PREFIRE_BINARY_PATH=/nonexistent $bin --version 2>&1 || true)
+          if echo "$output" | grep -q "failed to launch"; then
+            echo "override error path works"
+          else
+            echo "expected 'failed to launch' error, got: $output" >&2
+            exit 1
+          fi

--- a/Example/PreFireExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/PreFireExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ac988f1bdd201a27034cd4efa451ebe5806e0fd8b0ac226a19cbd79e07ebdb21",
+  "originHash" : "a82b8b030d4583df3b943405bbe44147dc3267ae29526f500271ee737fec1818",
   "pins" : [
     {
       "identity" : "accessibilitysnapshot",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "74203046135342e4a4a627476dd6caf8b28fe11b",
-        "version" : "509.0.0"
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "Prefire",
-    platforms: [.iOS(.v14)],
+    platforms: [.iOS(.v14), .macOS(.v13)],
     products: [
         .library(
             name: "Prefire",
@@ -19,11 +19,21 @@ let package = Package(
             name: "PrefireTestsPlugin",
             targets: ["PrefireTestsPlugin"]
         ),
+        .executable(
+            name: "prefire",
+            targets: ["PrefireCLI"]
+        ),
     ],
     targets: [
         .target(
             name: "Prefire",
             dependencies: []
+        ),
+        .executableTarget(
+            name: "PrefireCLI",
+            dependencies: [
+                "PrefireBinary",
+            ]
         ),
         .plugin(
             name: "PrefirePlaybookPlugin",

--- a/Package.swift
+++ b/Package.swift
@@ -35,6 +35,10 @@ let package = Package(
                 .copy("../../Binaries/PrefireBinary.artifactbundle"),
             ]
         ),
+        .testTarget(
+            name: "PrefireCLITests",
+            dependencies: ["PrefireCLI"]
+        ),
         .plugin(
             name: "PrefirePlaybookPlugin",
             capability: .buildTool(),

--- a/Package.swift
+++ b/Package.swift
@@ -31,9 +31,6 @@ let package = Package(
         ),
         .executableTarget(
             name: "PrefireCLI",
-            dependencies: [
-                "PrefireBinary",
-            ],
             resources: [
                 .copy("../../Binaries/PrefireBinary.artifactbundle"),
             ]

--- a/Package.swift
+++ b/Package.swift
@@ -33,6 +33,9 @@ let package = Package(
             name: "PrefireCLI",
             dependencies: [
                 "PrefireBinary",
+            ],
+            resources: [
+                .copy("../../Binaries/PrefireBinary.artifactbundle"),
             ]
         ),
         .plugin(

--- a/README.md
+++ b/README.md
@@ -88,9 +88,20 @@ Supports:
 - ✅ SPM Plugin (`Package.swift`)
 - ✅ Xcode Build Tool Plugin
 - ✅ CLI (`brew install prefire`)
+- ✅ Mint (*Beta*) (`mint install BarredEwe/Prefire`)
 - ✅ GitHub Actions / CI
 
 See detailed setup in the [Installation guide](https://github.com/BarredEwe/Prefire/blob/main/Installation.md)
+
+### Mint
+
+Install the bundled CLI via [Mint](https://github.com/yonaskolb/Mint):
+
+```sh
+mint install BarredEwe/Prefire
+```
+
+The installed `prefire` command proxies to the packaged `PrefireBinary`, so new releases work the same as the standalone binary. Set `PREFIRE_BINARY_PATH` if you keep the artifact in a custom location.
 
 ## 🧠 How It Works
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Install the bundled CLI via [Mint](https://github.com/yonaskolb/Mint):
 mint install BarredEwe/Prefire
 ```
 
-The installed `prefire` command proxies to the packaged `PrefireBinary`, so new releases work the same as the standalone binary. Set `PREFIRE_BINARY_PATH` if you keep the artifact in a custom location.
+The installed `prefire` wrapper ships the `PrefireBinary` artifactbundle as an embedded SwiftPM resource, so it is self-contained — no external binary path is required. To override the path of the embedded binary (e.g. for local development against an in-progress build), set `PREFIRE_BINARY_PATH` to the absolute path of the `prefire` executable.
 
 ## 🧠 How It Works
 

--- a/Sources/PrefireCLI/BinaryLocator.swift
+++ b/Sources/PrefireCLI/BinaryLocator.swift
@@ -1,0 +1,35 @@
+#if os(macOS)
+
+import Foundation
+
+enum BinaryLocator {
+    static let bundleName = "PrefireBinary.artifactbundle"
+
+    static func firstExecutable(in bundleURL: URL) -> String? {
+        let names = (try? FileManager.default.contentsOfDirectory(atPath: bundleURL.path)) ?? []
+        for name in names {
+            let bin = bundleURL.appendingPathComponent(name).appendingPathComponent("bin/prefire")
+            if FileManager.default.isExecutableFile(atPath: bin.path) { return bin.path }
+        }
+        return nil
+    }
+
+    static func candidateBundleURLs(resourceURL: URL? = Bundle.module.resourceURL, cwd: String = FileManager.default.currentDirectoryPath) -> [URL] {
+        var urls: [URL] = []
+        if let resourceURL {
+            urls.append(resourceURL.appendingPathComponent(bundleName, isDirectory: true))
+        }
+        urls.append(URL(fileURLWithPath: cwd).appendingPathComponent("Binaries").appendingPathComponent(bundleName, isDirectory: true))
+        return urls
+    }
+
+    static func findBinary(env: [String: String] = ProcessInfo.processInfo.environment, resourceURL: URL? = Bundle.module.resourceURL, cwd: String = FileManager.default.currentDirectoryPath) -> String? {
+        if let override = env["PREFIRE_BINARY_PATH"], !override.isEmpty { return override }
+        for url in candidateBundleURLs(resourceURL: resourceURL, cwd: cwd) {
+            if let bin = firstExecutable(in: url) { return bin }
+        }
+        return nil
+    }
+}
+
+#endif

--- a/Sources/PrefireCLI/main.swift
+++ b/Sources/PrefireCLI/main.swift
@@ -2,33 +2,9 @@
 
 import Foundation
 
-let env = ProcessInfo.processInfo.environment
-let bundleName = "PrefireBinary.artifactbundle"
-
-func firstBinary(in bundleURL: URL) -> String? {
-    let names = (try? FileManager.default.contentsOfDirectory(atPath: bundleURL.path)) ?? []
-    for name in names.sorted().reversed() {
-        let bin = bundleURL.appendingPathComponent(name).appendingPathComponent("bin/prefire")
-        if FileManager.default.isExecutableFile(atPath: bin.path) { return bin.path }
-    }
-    return nil
-}
-
-func findBinary() -> String? {
-    if let override = env["PREFIRE_BINARY_PATH"], !override.isEmpty { return override }
-
-    if let resourceURL = Bundle.module.resourceURL {
-        let bundleURL = resourceURL.appendingPathComponent(bundleName, isDirectory: true)
-        if let bin = firstBinary(in: bundleURL) { return bin }
-    }
-
-    let cwdBundle = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-        .appendingPathComponent("Binaries").appendingPathComponent(bundleName, isDirectory: true)
-    return firstBinary(in: cwdBundle)
-}
-
-guard let binaryPath = findBinary() else {
-    FileHandle.standardError.write(Data("prefire: unable to locate PrefireBinary\n".utf8))
+guard let binaryPath = BinaryLocator.findBinary() else {
+    let checked = BinaryLocator.candidateBundleURLs().map(\.path).joined(separator: "\n  ")
+    FileHandle.standardError.write(Data("prefire: unable to locate PrefireBinary. Checked:\n  \(checked)\n".utf8))
     exit(EXIT_FAILURE)
 }
 

--- a/Sources/PrefireCLI/main.swift
+++ b/Sources/PrefireCLI/main.swift
@@ -1,0 +1,49 @@
+#if os(macOS)
+
+import Foundation
+
+let env = ProcessInfo.processInfo.environment
+let bundleRel = "Binaries/PrefireBinary.artifactbundle"
+
+func firstBinary(in base: URL) -> String? {
+    let bundle = base.appendingPathComponent(bundleRel, isDirectory: true)
+    guard let names = try? FileManager.default.contentsOfDirectory(atPath: bundle.path) else { return nil }
+    for name in names {
+        let bin = bundle.appendingPathComponent(name).appendingPathComponent("bin/prefire")
+        if FileManager.default.isExecutableFile(atPath: bin.path) { return bin.path }
+    }
+    return nil
+}
+
+func findBinary() -> String? {
+    if let override = env["PREFIRE_BINARY_PATH"], !override.isEmpty { return override }
+
+    let exeBase = (0..<4).reduce(URL(fileURLWithPath: CommandLine.arguments[0]).resolvingSymlinksInPath()) { url, _ in url.deletingLastPathComponent() }
+    let srcBase = URL(fileURLWithPath: #filePath).deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+    let cwdBase = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+
+    return firstBinary(in: exeBase) ?? firstBinary(in: srcBase) ?? firstBinary(in: cwdBase)
+}
+
+guard let binaryPath = findBinary() else {
+    FileHandle.standardError.write(Data("prefire: unable to locate PrefireBinary\n".utf8))
+    exit(EXIT_FAILURE)
+}
+
+let process = Process()
+process.executableURL = URL(fileURLWithPath: binaryPath)
+process.arguments = Array(CommandLine.arguments.dropFirst())
+process.standardInput = FileHandle.standardInput
+process.standardOutput = FileHandle.standardOutput
+process.standardError = FileHandle.standardError
+
+do {
+    try process.run()
+    process.waitUntilExit()
+    exit(process.terminationStatus)
+} catch {
+    FileHandle.standardError.write(Data("prefire: failed to launch: \(error)\n".utf8))
+    exit(EXIT_FAILURE)
+}
+
+#endif

--- a/Sources/PrefireCLI/main.swift
+++ b/Sources/PrefireCLI/main.swift
@@ -3,13 +3,12 @@
 import Foundation
 
 let env = ProcessInfo.processInfo.environment
-let bundleRel = "Binaries/PrefireBinary.artifactbundle"
+let bundleName = "PrefireBinary.artifactbundle"
 
-func firstBinary(in base: URL) -> String? {
-    let bundle = base.appendingPathComponent(bundleRel, isDirectory: true)
-    guard let names = try? FileManager.default.contentsOfDirectory(atPath: bundle.path) else { return nil }
-    for name in names {
-        let bin = bundle.appendingPathComponent(name).appendingPathComponent("bin/prefire")
+func firstBinary(in bundleURL: URL) -> String? {
+    let names = (try? FileManager.default.contentsOfDirectory(atPath: bundleURL.path)) ?? []
+    for name in names.sorted().reversed() {
+        let bin = bundleURL.appendingPathComponent(name).appendingPathComponent("bin/prefire")
         if FileManager.default.isExecutableFile(atPath: bin.path) { return bin.path }
     }
     return nil
@@ -18,11 +17,14 @@ func firstBinary(in base: URL) -> String? {
 func findBinary() -> String? {
     if let override = env["PREFIRE_BINARY_PATH"], !override.isEmpty { return override }
 
-    let exeBase = (0..<4).reduce(URL(fileURLWithPath: CommandLine.arguments[0]).resolvingSymlinksInPath()) { url, _ in url.deletingLastPathComponent() }
-    let srcBase = URL(fileURLWithPath: #filePath).deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
-    let cwdBase = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+    if let resourceURL = Bundle.module.resourceURL {
+        let bundleURL = resourceURL.appendingPathComponent(bundleName, isDirectory: true)
+        if let bin = firstBinary(in: bundleURL) { return bin }
+    }
 
-    return firstBinary(in: exeBase) ?? firstBinary(in: srcBase) ?? firstBinary(in: cwdBase)
+    let cwdBundle = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        .appendingPathComponent("Binaries").appendingPathComponent(bundleName, isDirectory: true)
+    return firstBinary(in: cwdBundle)
 }
 
 guard let binaryPath = findBinary() else {

--- a/Tests/PrefireCLITests/BinaryLocatorTests.swift
+++ b/Tests/PrefireCLITests/BinaryLocatorTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import PrefireCLI
+
+final class BinaryLocatorTests: XCTestCase {
+    func testFirstExecutableFindsEmbeddedBinary() throws {
+        let bundleURL = try XCTUnwrap(
+            Bundle.module.resourceURL?.appendingPathComponent(BinaryLocator.bundleName, isDirectory: true),
+            "PrefireCLI must ship with the bundled PrefireBinary artifact"
+        )
+        let bin = try XCTUnwrap(BinaryLocator.firstExecutable(in: bundleURL), "expected an executable inside the bundled artifact")
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: bin), "\(bin) must be executable")
+    }
+
+    func testFirstExecutableReturnsNilForEmptyDirectory() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("PrefireCLITests-empty-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        XCTAssertNil(BinaryLocator.firstExecutable(in: dir))
+    }
+
+    func testFindBinaryPrefersEnvOverride() {
+        let bin = BinaryLocator.findBinary(
+            env: ["PREFIRE_BINARY_PATH": "/usr/bin/true"],
+            resourceURL: nil,
+            cwd: "/nonexistent-\(UUID().uuidString)"
+        )
+        XCTAssertEqual(bin, "/usr/bin/true")
+    }
+
+    func testFindBinaryIgnoresEmptyEnvOverride() throws {
+        let bundleURL = try XCTUnwrap(Bundle.module.resourceURL?.appendingPathComponent(BinaryLocator.bundleName, isDirectory: true))
+        let bin = BinaryLocator.findBinary(env: ["PREFIRE_BINARY_PATH": ""], resourceURL: bundleURL.deletingLastPathComponent(), cwd: "/tmp")
+        XCTAssertNotNil(bin, "empty override must fall through to resource lookup")
+    }
+
+    func testFindBinaryFindsViaResourceURL() {
+        let bin = BinaryLocator.findBinary(env: [:], resourceURL: Bundle.module.resourceURL, cwd: "/nonexistent-\(UUID().uuidString)")
+        XCTAssertNotNil(bin)
+    }
+
+    func testFindBinaryReturnsNilWhenNothingAvailable() {
+        let bin = BinaryLocator.findBinary(
+            env: [:],
+            resourceURL: URL(fileURLWithPath: "/nonexistent-\(UUID().uuidString)/Resources"),
+            cwd: "/nonexistent-\(UUID().uuidString)"
+        )
+        XCTAssertNil(bin)
+    }
+
+    func testCandidateBundleURLsAlwaysIncludesCwdFallback() {
+        let urls = BinaryLocator.candidateBundleURLs(resourceURL: nil, cwd: "/tmp")
+        XCTAssertEqual(urls.count, 1)
+        XCTAssertEqual(urls[0].path, "/tmp/Binaries/\(BinaryLocator.bundleName)")
+    }
+}


### PR DESCRIPTION
### Short description 📝
Adds Mint (https://github.com/yonaskolb/Mint) support for installing prefire and makes the wrapper self-contained — the PrefireBinary artifactbundle is now embedded as a SwiftPM resource inside PrefireCLI, so the installed binary works from any directory with no external path setup. Several bugs in the initial commit are fixed and the logic is split out for testability.
### Solution 📦
The first iteration committed a thin wrapper that tried to locate the bundled PrefireBinary by walking up directories from the executable path. It didn't compile (closure arity, Process.standardInput is Any?) and, once fixed, still didn't work in mint — mint only retains the built executable in its cache, so neither the cwd, the exe-relative lookups, nor the build-time #filePath had a Binaries/ directory to find.
The fix is to embed the artifactbundle into the wrapper itself via a SwiftPM resources: [.copy(...)] entry. The wrapper then resolves it through Bundle.module at runtime. This works equally well in mint (where only the executable survives) and for the Xcode SPM plugin flows, because the bundle travels with the binary.
The Bundle.module lookup is the primary strategy; a cwd/Binaries/... fallback is kept for dev mode (running the wrapper from a local source checkout). PREFIRE_BINARY_PATH overrides both.
Other cleanups done in the same PR:
- extracted the lookup logic into BinaryLocator enum so it can be unit-tested and parameterised (env, resourceURL, cwd) without touching the entry point
- error message now lists the paths that were checked
- dropped the unused PrefireBinary dependency from PrefireCLI (plugins still depend on it)
- README updated to reflect that the wrapper is self-contained
Alternatives considered but not taken:
- moving the artifactbundle into Sources/PrefireCLI/Resources/ would silence SwiftPM's "Found unhandled resource" warning but duplicates the bundle path between the binary target and the resource — left for a follow-up
- embedding the binary directly into the Mach-O via -sectcreate would be cleanest but adds link-time complexity
Implementation 👩‍💻👨‍💻
- Add PrefireCLI executable target with executable product
- Fix compile errors in initial main.swift (closure arity, FileHandle.standardInput)
- Switch lookup strategy to Bundle.module via SwiftPM resources: [.copy(...)]
- Drop dependencies: ["PrefireBinary"] from PrefireCLI (unused)
- Extract logic into Sources/PrefireCLI/BinaryLocator.swift
- Improve error message to list checked paths
- Add PrefireCLITests test target with 7 unit tests (currently blocked on macOS by the iOS-only Prefire library — kept for when that is addressed)
- Add CI smoke step that builds the wrapper, runs it from cwd and /tmp, and exercises the PREFIRE_BINARY_PATH error path
- Update README: "Mint" section now states the wrapper is self-contained and documents the override
Verification
- swift build -c release --product prefire builds clean
- mint install BarredEwe/Prefire@supportMint builds and links
- Wrapper runs successfully from /tmp, /, and arbitrary cwd
- --help, --version, subcommand help, and exit code propagation all work
- PREFIRE_BINARY_PATH=/nonexistent prefire --version exits 1 with a clear error
###  Notes
- Known: SwiftPM prints Found unhandled resource at .../Binaries/PrefireBinary.artifactbundle because the resource path goes up two levels from the target. The build still succeeds; silencing this requires relocating the bundle.
- The unit-test target is wired up but swift test on this package fails to build the iOS-only Prefire library on macOS. The smoke test in CI is what actually gates regressions on the wrapper today.