### PR TITLE
Fixed issue where config paths containing spaces

### DIFF
--- a/Plugins/PrefireTestsPlugin/Plugin.swift
+++ b/Plugins/PrefireTestsPlugin/Plugin.swift
@@ -29,7 +29,7 @@ struct PrefireTestsPlugin: BuildToolPlugin {
 
         let environment = [
             "TARGET_DIR": String(describing: target.directory),
-            "PACKAGE_DIR": context.package.directoryURL.path(),
+            "PACKAGE_DIR": context.package.directoryURL.path(percentEncoded: false),
         ]
 
         return [
@@ -74,7 +74,7 @@ struct PrefireTestsPlugin: BuildToolPlugin {
             arguments.append(contentsOf: sources)
 
             let environment = [
-                "PROJECT_DIR": context.xcodeProject.directoryURL.path(),
+                "PROJECT_DIR": context.xcodeProject.directoryURL.path(percentEncoded: false),
             ]
 
             return [

--- a/PrefireExecutable/Sources/prefire/Commands/Playbook/GeneratePlaybookCommand.swift
+++ b/PrefireExecutable/Sources/prefire/Commands/Playbook/GeneratePlaybookCommand.swift
@@ -27,7 +27,7 @@ struct GeneratedPlaybookOptions {
         if let template = config?.playbook.template, let targetPath {
             let targetURL = URL(filePath: targetPath)
             let templateURL = targetURL.appending(path: template)
-            self.template = Path(templateURL.absoluteURL.path())
+            self.template = Path(templateURL.absoluteURL.path(percentEncoded: false))
         } else if let template {
             self.template = Path(template)
         }

--- a/PrefireExecutable/Sources/prefire/Commands/Tests/GenerateTestsCommand.swift
+++ b/PrefireExecutable/Sources/prefire/Commands/Tests/GenerateTestsCommand.swift
@@ -42,7 +42,7 @@ struct GeneratedTestsOptions {
         if let template = config?.tests.template, let testTargetPath = self.testTargetPath {
             let testTargetURL = URL(filePath: testTargetPath.string)
             let templateURL = testTargetURL.appending(path: template)
-            self.template = Path(templateURL.absoluteURL.path())
+            self.template = Path(templateURL.absoluteURL.path(percentEncoded: false))
         } else if let template {
             self.template = Path(template)
         }

--- a/PrefireExecutable/Sources/prefire/Config/ConfigPathBuilder.swift
+++ b/PrefireExecutable/Sources/prefire/Config/ConfigPathBuilder.swift
@@ -24,12 +24,12 @@ enum ConfigPathBuilder {
                 configURL.append(component: configFileName)
             }
 
-            possibleConfigPaths.append(configURL.absoluteURL.path())
+            possibleConfigPaths.append(configURL.absoluteURL.path(percentEncoded: false))
         }
 
         // Add the default path
         let configURL = URL(filePath: configFileName) // Relative to the current directory
-        possibleConfigPaths.append(configURL.absoluteURL.path())
+        possibleConfigPaths.append(configURL.absoluteURL.path(percentEncoded: false))
 
         return possibleConfigPaths
     }


### PR DESCRIPTION
Fixed issue where config paths containing spaces were being percent-encoded (e.g., "root/a aaa/.prefire.yml" became "root/a%20aaa/.prefire.yml"), causing FileManager.default.fileExists(atPath:) to fail.

Added percentEncoded: false parameter to path() call to ensure spaces and special characters are properly handled.

## Steps to reproduce
1. Create a `.prefire.yml` file in the folder with spaces in name. ex: `test folder/.prefire.yml`
2. Run `prefire tests --config {path to the config} --verbose`
3. Script will return an error: `🟡 The '.prefire' file was not found by paths: {your path}`
