### PR TITLE
Fix a crash when #Preview is followed by a newline

### DIFF
--- a/PrefireExecutable/Sources/PrefireCore/Previews/PreviewLoader.swift
+++ b/PrefireExecutable/Sources/PrefireCore/Previews/PreviewLoader.swift
@@ -23,24 +23,28 @@ enum PreviewLoader {
         var currentBody: String = ""
         var previewWasFound = false
         var viewMustBeLoaded = defaultEnabled
-        var braceBalance = 0
+        var braceBalance: Int? = nil
 
         for line in lines {
             if line.hasPrefix(Constants.previewMarker) {
                 previewWasFound = true
                 currentBody = ""
-                braceBalance = 0
+                braceBalance = nil
             }
 
             guard previewWasFound else { continue }
 
-            braceBalance += line.reduce(0) { (count, char) in
+            let braceChange = line.reduce(0) { (count, char) in
                 if char == Constants.openingBrace {
                     return count + 1
                 } else if char == Constants.closingBrace {
                     return count - 1
                 }
                 return count
+            }
+
+            if braceChange != 0 || braceBalance != nil {
+                braceBalance = (braceBalance ?? 0) + braceChange
             }
 
             if defaultEnabled {

--- a/PrefireExecutable/Tests/PrefireTests/Fixtures/TestPreview.swift
+++ b/PrefireExecutable/Tests/PrefireTests/Fixtures/TestPreview.swift
@@ -23,3 +23,11 @@ let fixtureTestPreviewSource = #filePath
     @Previewable @State var foo: Bool = false
     Text("TestPreview_WithProperties")
 }
+
+#Preview
+{
+    VStack
+    {
+        Text("Preview formatted with Allman")
+    }
+}

--- a/PrefireExecutable/Tests/PrefireTests/PreviewLoaderTests.swift
+++ b/PrefireExecutable/Tests/PrefireTests/PreviewLoaderTests.swift
@@ -8,7 +8,8 @@ class PreviewLoaderTests: XCTestCase {
         "#Preview {\n    Text(\"TestView_Prefire\")\n        .prefireEnabled()\n}\n",
         "#Preview {\n    Text(\"TestPreview\")\n}\n",
         "#Preview {\n    Text(\"TestPreview_Prefire\")\n        .prefireEnabled()\n}\n",
-        "#Preview(\"Preview with properties\") {\n    @Previewable @State var foo: Bool = false\n    Text(\"TestPreview_WithProperties\")\n}\n"
+        "#Preview(\"Preview with properties\") {\n    @Previewable @State var foo: Bool = false\n    Text(\"TestPreview_WithProperties\")\n}\n",
+        "#Preview\n{\n    VStack\n    {\n        Text(\"Preview formatted with Allman\")\n    }\n}\n"
     ]
 
     let source = #filePath
@@ -34,10 +35,11 @@ class PreviewLoaderTests: XCTestCase {
         let content = try String(contentsOf: URL(filePath: fixtureTestPreviewSource), encoding: .utf8)
         let previews = PreviewLoader.previewBodies(from: content, defaultEnabled: true)
 
-        XCTAssertEqual(previews?.count, 3)
+        XCTAssertEqual(previews?.count, 4)
         XCTAssertEqual(previews?[0], previewRepresentations[2])
         XCTAssertEqual(previews?[1], previewRepresentations[3])
 		XCTAssertEqual(previews?[2], previewRepresentations[4])
+        XCTAssertEqual(previews?[3], previewRepresentations[5])
     }
 
     func test_loadRawPreviewBodiesDefaultDisabledAndUrlIsDirectory() async throws {


### PR DESCRIPTION
### Short description 📝
Fix issue #145. Add support for Allman style, or whenever the first brace opening the preview is not on the same line as `#Preview`. 

### Solution 📦
Check during #Preview line parsing if it contains a brace and should start counting braces or not. 
Instead of adding a flag `hasBraceOnFirstLine`, I preferred to make braceBalance nullable. So we assign 0 only when the last brace is closed. 

### Tests 🧪
I added a test case with a simple Preview in Allman style and just added an assertion to an existing test : `test_loadRawPreviewBodiesDefaultEnableAndUrlIsDirectory`. 