### PR TITLE
Add ViewBuilder capacity to preview variables in the test template

### DIFF
--- a/Example/Shared/Examples/TestView.swift
+++ b/Example/Shared/Examples/TestView.swift
@@ -87,8 +87,27 @@ struct GreenButton_Previews: PreviewProvider, PrefireProvider {
 }
 
 #Preview(traits: .sizeThatFitsLayout) {
-    TestView(isLoading: true)
-        .previewUserStory(.testStory)
-        .snapshot(delay: 0.1, precision: 0.9)
-        .previewUserStory(.auth)
+    let userStory: PreviewModel.UserStory = .testStory
+    VStack
+    {
+        TestView(isLoading: true)
+            .previewUserStory(userStory)
+            .snapshot(delay: 0.1, precision: 0.9)
+            .previewUserStory(.auth)
+    }.padding()
+}
+
+#Preview(traits: .sizeThatFitsLayout) {
+        TestView(isLoading: false)
+            .previewUserStory(.testStory)
+            .snapshot(delay: 0.5, precision: 0.7)
+        
+        TestView(isLoading: true)
+            .previewUserStory(.testStory)
+            .previewState(.loading)
+        
+        TestView(isLoading: true)
+            .previewUserStory(.testStory)
+            .previewState(.loading)
+            .snapshot(delay: 0.3, precision: 0.9)
 }

--- a/PrefireExecutable/Sources/PrefireCore/Templates/PreviewModelsTemplates.swift
+++ b/PrefireExecutable/Sources/PrefireCore/Templates/PreviewModelsTemplates.swift
@@ -73,7 +73,7 @@ private struct MacroPreviews {
         PreviewModel(content: { PreviewWrapper{{ macroModel.componentTestName }}() }, name: "{{ macroModel.displayName }}"),
         {% else %}
         PreviewModel(content: {
-        {{ macroModel.body|indent:8 }}
+            {{ macroModel.body|indent:12 }}
         }, name: "{{ macroModel.displayName }}"),
         {% endif %}
         {% endfor %}

--- a/PrefireExecutable/Sources/PrefireCore/Templates/PreviewTestsTemplate.swift
+++ b/PrefireExecutable/Sources/PrefireCore/Templates/PreviewTestsTemplate.swift
@@ -61,26 +61,29 @@ import SnapshotTesting
     // MARK: - Macros
 
     {% for macroModel in argument.previewsMacrosDict %}
-    func test_{{ macroModel.componentTestName }}_Preview() {
+    func test_{{ macroModel.componentTestName }}_Preview() {        
         {% if macroModel.properties %}
         struct PreviewWrapper{{ macroModel.componentTestName }}: SwiftUI.View {
-        {{ macroModel.properties }}
+            {{ macroModel.properties }}
             var body: some View {
-            {{ macroModel.body|indent:12 }}
+                {{ macroModel.body|indent:12 }}
             }
         }
-        let preview = PreviewWrapper{{ macroModel.componentTestName }}.init
-        {% else %}
-        let preview = {
-        {{ macroModel.body|indent:8 }}
-        }
         {% endif %}
-        {% if macroModel.isScreen == 1 %}
-        let isScreen = true
-        {% else %}
-        let isScreen = false
-        {% endif %}
-        if let failure = assertSnapshots(for: PrefireSnapshot(preview(), name: "{{ macroModel.displayName }}", isScreen: isScreen, device: deviceConfig)) {
+        let prefireSnapshot = PrefireSnapshot(
+            {
+                {% if macroModel.properties %}
+                PreviewWrapper{{ macroModel.componentTestName }}()
+                {% else %}
+                {{ macroModel.body|indent:12 }}
+                {% endif %}
+            },
+            name: "{{ macroModel.displayName }}",
+            isScreen: {% if macroModel.isScreen == 1 %}true{% else %}false{% endif %},
+            device: deviceConfig
+        )
+
+        if let failure = assertSnapshots(for: prefireSnapshot) {
             XCTFail(failure)
         }
     }

--- a/Sources/Prefire/Preview/PrefireSnapshot.swift
+++ b/Sources/Prefire/Preview/PrefireSnapshot.swift
@@ -39,24 +39,26 @@ public struct DeviceConfig {
         self.device = device
     }
 
-    public init(_ view: Content, name: String, isScreen: Bool, device: DeviceConfig, traits: UITraitCollection = .init()) {
-        previewContent = view
+    public init(@ViewBuilder _ view: @escaping @MainActor () -> Content, name: String, isScreen: Bool, device: DeviceConfig, traits: UITraitCollection = .init()) {
+        previewContent = view()
         self.name = name
         self.isScreen = isScreen
         self.device = device
         self.traits = traits
     }
-
-    public init(_ view: UIView, name: String, isScreen: Bool, device: DeviceConfig, traits: UITraitCollection = .init()) where Content == ViewRepresentable<UIView> {
-        previewContent = ViewRepresentable(view: view)
+    
+    @_disfavoredOverload
+    public init<T: UIView>(_ view: @escaping @MainActor () -> T, name: String, isScreen: Bool, device: DeviceConfig, traits: UITraitCollection = .init()) where Content == ViewRepresentable<T> {
+        previewContent = ViewRepresentable(view: view())
         self.name = name
         self.isScreen = isScreen
         self.device = device
         self.traits = traits
     }
-
-    public init(_ viewController: UIViewController, name: String, isScreen: Bool, device: DeviceConfig, traits: UITraitCollection = .init()) where Content == ViewControllerRepresentable<UIViewController> {
-        previewContent = ViewControllerRepresentable(viewController: viewController)
+    
+    @_disfavoredOverload
+    public init<T: UIViewController>(_ viewController: @escaping @MainActor () -> T, name: String, isScreen: Bool, device: DeviceConfig, traits: UITraitCollection = .init()) where Content == ViewControllerRepresentable<T> {
+        previewContent = ViewControllerRepresentable(viewController: viewController())
         self.name = name
         self.isScreen = isScreen
         self.device = device

--- a/Sources/Prefire/Preview/PreviewModel.swift
+++ b/Sources/Prefire/Preview/PreviewModel.swift
@@ -72,9 +72,9 @@ public struct PreviewModel: Identifiable {
     }
 
     @MainActor
-    public init(
+    public init<T: UIView>(
         id: String? = nil,
-        content: @escaping () -> UIView,
+        content: @escaping @MainActor () -> T,
         name: String,
         type: LayoutType = .component,
         device: PreviewDevice? = nil
@@ -83,9 +83,9 @@ public struct PreviewModel: Identifiable {
     }
 
     @MainActor
-    public init(
+    public init<T: UIViewController>(
         id: String? = nil,
-        content: @escaping () -> UIViewController,
+        content: @escaping @MainActor () -> T,
         name: String,
         type: LayoutType = .component,
         device: PreviewDevice? = nil


### PR DESCRIPTION
### Short description 📝
The generated tests does not support `#Preview` with multiple views. Fix issue #146  

```swift
#Preview
{
    NXBadgeView(item: NXBadgeViewItem(icon: "generic_small_star_10", text: "4.0", color: .pink))
    NXBadgeView(item: NXBadgeViewItem(icon: nil, text: "Top award", color: .purple))
    NXBadgeView(item: NXBadgeViewItem(icon: nil, text: "Top award", color: .yellow, isLarge: true))
}
```
^ This preview generate a test that doesn't build. 

### Solution 📦
Because `#Preview` is of type `@ViewBuilder`, the preview variables, used in the generated tests, should also be `@ViewBuilder`. 

### Test 🧪 
I did not find any existing test for the `PreviewTestsTemplate`, but it would be nice to add some. @BarredEwe : Do you have some suggestions of tests I could add ?