### PR TITLE
Fix config file lookup when project path contains spaces

### DIFF
--- a/PrefireExecutable/Sources/prefire/Config/ConfigPathBuilder.swift
+++ b/PrefireExecutable/Sources/prefire/Config/ConfigPathBuilder.swift
@@ -16,8 +16,11 @@ enum ConfigPathBuilder {
                 continue
             }
 
+            // Decode any percent-encoded characters in the input path
+            let decodedPath = path.removingPercentEncoding ?? path
+
             // This will build the absolute path relative to the current directory
-            var configURL = URL(filePath: path)
+            var configURL = URL(filePath: decodedPath)
 
             // Add the config file name if not provided
             if configURL.lastPathComponent != configFileName {

--- a/PrefireExecutable/Tests/PrefireTests/ConfigPathBuilderTests.swift
+++ b/PrefireExecutable/Tests/PrefireTests/ConfigPathBuilderTests.swift
@@ -89,4 +89,16 @@ class ConfigPathBuilderTests: XCTestCase {
 
         XCTAssertEqual(result, expectableResult)
     }
+
+    func test_possibleConfigPathsWithPercentEncodedSpaces() {
+        let configPath = "Test%20Folder/" + configFileName
+        let result = ConfigPathBuilder.possibleConfigPaths(for: configPath, testTargetPath: nil, packagePath: nil)
+
+        let expectableResult = [
+            FileManager.default.currentDirectoryPath + "/Test Folder/" + configFileName,
+            FileManager.default.currentDirectoryPath + "/" + configFileName,
+        ]
+
+        XCTAssertEqual(result, expectableResult)
+    }
 }


### PR DESCRIPTION
### Short description 📝

Fixes an issue where the `.prefire.yml` config file is not found when the project path contains spaces. The plugin passes percent-encoded paths (e.g., `My%20Project`) which causes the file lookup to fail.

### Solution 📦

Decode percent-encoded characters in `ConfigPathBuilder.possibleConfigPaths()` before constructing the URL:

```swift
let decodedPath = path.removingPercentEncoding ?? path
var configURL = URL(filePath: decodedPath)
```

The root cause is that the plugin uses `String(describing: target.directory)` which percent-encodes spaces. Alternative fixes were considered:

1. **Change plugin to use `target.directory.string`** — This fixes the encoding but reintroduces deprecation warnings that were removed in #101.

2. **Change plugin to use `target.directoryURL.path(percentEncoded: false)`** — This is the ideal solution but `directoryURL` is only available in swift-tools-version 6.1+, and the package currently targets 6.0.

3. **Decode in the executable (this PR)** — A defensive fix that handles percent-encoded input regardless of source, requires no plugin changes, and introduces no warnings. This complements the fixes in #141.

### Implementation 👩‍💻👨‍💻

- [x] Add `removingPercentEncoding` call in `ConfigPathBuilder.possibleConfigPaths()` before creating URL from input path

Closes #153 