### PR TITLE
 Fix preview marker whitespace handling

### DIFF
--- a/Binaries/PrefireBinary.artifactbundle/info.json
+++ b/Binaries/PrefireBinary.artifactbundle/info.json
@@ -3,10 +3,10 @@
     "artifacts": {
         "PrefireBinary": {
             "type": "executable",
-            "version": "5.4.1",
+            "version": "5.4.2",
             "variants": [
                 {
-                    "path": "prefire-5.4.1-macos/bin/prefire",
+                    "path": "prefire",
                     "supportedTriples": ["x86_64-apple-macosx", "arm64-apple-macosx"]
                 },
             ]

--- a/PrefireExecutable/Sources/PrefireCore/Previews/PreviewLoader.swift
+++ b/PrefireExecutable/Sources/PrefireCore/Previews/PreviewLoader.swift
@@ -26,7 +26,7 @@ enum PreviewLoader {
         var braceBalance: Int? = nil
 
         for line in lines {
-            if line.hasPrefix(Constants.previewMarker) {
+            if line.trimmingCharacters(in: .whitespaces).hasPrefix(Constants.previewMarker) {
                 previewWasFound = true
                 currentBody = ""
                 braceBalance = nil


### PR DESCRIPTION
### Short description 📝
This PR fixes a bug where preview markers with leading/trailing whitespace were not being detected correctly.

### Solution 📦
The preview marker check was failing when the marker string had unexpected whitespace. The fix trims the string before checking, ensuring robust detection regardless of formatting.

### Implementation 👩‍💻👨‍💻
- [x] Fix whitespace handling in `PreviewLoader.swift` by trimming string before marker check
- [x] Rebuild binary with fix and reorganize artifact bundle structure
