### PR TITLE
Fixed an issue where configuration files with trailing spaces could not be read

### DIFF
--- a/PrefireExecutable/Sources/prefire/Config/ConfigDecoder.swift
+++ b/PrefireExecutable/Sources/prefire/Config/ConfigDecoder.swift
@@ -103,7 +103,8 @@ final class ConfigDecoder {
     }
 
     private func getValues(from components: [String], lines: ArraySlice<String>, env: [String: String]) -> [String]? {
-        guard components.last?.isEmpty == true else { return nil }
+        guard let lastComponent = components.last?.trimmingCharacters(in: .whitespaces),
+              lastComponent.isEmpty == true else { return nil }
 
         var values = [String]()
 

--- a/PrefireExecutable/Tests/PrefireTests/ConfigDecoderTests.swift
+++ b/PrefireExecutable/Tests/PrefireTests/ConfigDecoderTests.swift
@@ -30,11 +30,59 @@ class ConfigDecoderTests: XCTestCase {
               - SwiftUI
           - preview_default_enabled: false
     """
+    
+    private let prefireConfigStringWithWhiteSpaces = """
+        test_configuration: 
+          - target: PrefireExample   
+          - test_target_path: ${TARGET_DIR}/MyTests   
+          - test_file_path: ${TARGET_DIR}/PrefireExampleTests/PreviewTests.generated.swift 
+          - template_file_path: CustomPreviewTests.stencil 
+          - simulator_device: "iPhone15,2" 
+          - required_os: 17 
+          - snapshot_devices:  
+              - iPhone 15   
+              - iPad 
+          - preview_default_enabled: true 
+          - imports: 
+              - UIKit 
+              - SwiftUI 
+          - testable_imports: 
+              - Prefire 
+          - draw_hierarchy_in_key_window_default_enabled: true 
+        playbook_configuration: 
+          - template_file_path: CustomModels.stencil 
+          - imports: 
+              - UIKit 
+              - Foundation  
+          - testable_imports: 
+              - SwiftUI 
+          - preview_default_enabled: false 
+    """
 
     private let env = ["TARGET_DIR":"/User/Tests"]
 
     func test_successDecodeConfig() {
         let config = ConfigDecoder().decode(from: prefireConfigString, env: env)
+
+        XCTAssertEqual(config.tests.target, "PrefireExample")
+        XCTAssertEqual(config.tests.testTargetPath, "/User/Tests/MyTests")
+        XCTAssertEqual(config.tests.testFilePath, "/User/Tests/PrefireExampleTests/PreviewTests.generated.swift")
+        XCTAssertEqual(config.tests.template, "CustomPreviewTests.stencil")
+        XCTAssertEqual(config.tests.device, "iPhone15,2")
+        XCTAssertEqual(config.tests.osVersion, "17")
+        XCTAssertEqual(config.tests.snapshotDevices, ["iPhone 15", "iPad"])
+        XCTAssertEqual(config.tests.previewDefaultEnabled, true)
+        XCTAssertEqual(config.tests.imports, ["UIKit", "SwiftUI"])
+        XCTAssertEqual(config.tests.testableImports, ["Prefire"])
+        XCTAssertEqual(config.tests.drawHierarchyInKeyWindowDefaultEnabled, true)
+        XCTAssertEqual(config.playbook.imports, ["UIKit", "Foundation"])
+        XCTAssertEqual(config.playbook.testableImports, ["SwiftUI"])
+        XCTAssertEqual(config.playbook.template, "CustomModels.stencil")
+        XCTAssertEqual(config.playbook.previewDefaultEnabled, false)
+    }
+    
+    func test_successDecodeConfig_with_whiteSpaces() {
+        let config = ConfigDecoder().decode(from: prefireConfigStringWithWhiteSpaces, env: env)
 
         XCTAssertEqual(config.tests.target, "PrefireExample")
         XCTAssertEqual(config.tests.testTargetPath, "/User/Tests/MyTests")


### PR DESCRIPTION
### Short description 📝
Fix an issue where list-type config values (snapshot_devices, imports, testable_imports,
  etc.) are silently ignored when the key line has a trailing space

Concrete example: In the following config file, if snapshot_devices:, imports:, or testable_imports: have a trailing space, all list values under that key are silently ignored.

```yml
test_configuration:
    - target: PrefireExample
    - test_target_path: ${TARGET_DIR}/MyTests
    - test_file_path: ${TARGET_DIR}/PrefireExampleTests/PreviewTests.generated.swift
    - template_file_path: CustomPreviewTests.stencil
    - simulator_device: "iPhone15,2"
    - required_os: 17
    - snapshot_devices:              # ← trailing space → "iPhone 15" and "iPad" are not
  read
        - iPhone 15
        - iPad
    - preview_default_enabled: true
    - imports:                       # ← trailing space → "UIKit" and "SwiftUI" are not
  read
        - UIKit
        - SwiftUI
    - testable_imports:              # ← trailing space → "Prefire" is not read
        - Prefire
```

### Solution 📦
The root cause was in `ConfigDecoder.swift`: the `getValues(from:lines:env:)` method checked
if components.last was empty, but trailing whitespace caused the check to fail even for
semantically empty values.

The fix trims whitespace from the last component before checking emptiness, so lines like imports:  (with a trailing space) are correctly recognized as the start of a list block.

Alternative considered: stripping whitespace from the entire line before splitting into
components, but this would have a wider impact and could unintentionally affect indentation-sensitive parsing.

### Implementation 👩‍💻👨‍💻
- [x] Applied .trimmingCharacters(in: .whitespaces) to components.last before the empty check
- [x] Added prefireConfigStringWithWhiteSpaces test fixture with trailing spaces on every
 value line
- [x] Added test_successDecodeConfig_with_whiteSpaces() test case to ConfigDecoderTests.swift
