### PR TITLE
Fix CI: update Xcode version to 26.4 on macos-26 runner

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - xcode: "Xcode_16.4"
             runsOn: macos-15
-          - xcode: "Xcode_26.0"
+          - xcode: "Xcode_26.4"
             runsOn: macos-26
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes unrelated CI failure from https://github.com/BarredEwe/Prefire/pull/158

The `macos-26` GitHub runner no longer has `Xcode_26.0.app` — it has been replaced by a newer version. This causes the `xcode-select` step to fail, making the iOS Simulator unavailable and the build step unable to find a matching destination.

Updates the Xcode version from `26.0` to `26.4` to match what's currently available on the runner.

Made with [Cursor](https://cursor.com)