### PR TITLE
Split snapshot folders by source file under new `split_snapshot_directories` flag

### DIFF
--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -14,6 +14,7 @@ test_configuration:
   required_os: 16
   preview_default_enabled: true
   use_grouped_snapshots: true
+  split_snapshot_directories: false
   sources:
     - ${PROJECT_DIR}/Sources/
   snapshot_devices:
@@ -50,6 +51,7 @@ playbook_configuration:
 | `snapshot_devices`                             | List of logical snapshot "targets" (used as trait collections). Each will snapshot separately. Optional                                                                                                                                   |
 | `preview_default_enabled`                      | Should all detected previews be included by default? Set `false` if you want to require `.prefireEnabled()` manually. Default: `true`                                                                                                     |
 | `use_grouped_snapshots`                        | Generate a single test file with all previews (`true`) or separate test files per source file (`false`). When `false`, use `{PREVIEW_FILE_NAME}` placeholder in `test_file_path`. Default: `true`                                         |
+| `split_snapshot_directories`                   | When `use_grouped_snapshots: false`, also write snapshots into a separate `__Snapshots__/<File>Tests.generated/` folder per source file instead of one shared `__Snapshots__/PreviewTests.generated/` folder. Closes [#80](https://github.com/BarredEwe/Prefire/issues/80). Default: `false` to keep existing snapshot layouts working — opt in once you're ready to move the files.                |
 | `sources`                                      | List of Swift files or folders to scan for previews. Defaults to inferred from the target                                                                                                                                                 |
 | `imports`                                      | Extra imports added to the generated test or playbook file                                                                                                                                                                                |
 | `testable_imports`                             | Extra `@testable` imports added to allow test visibility                                                                                                                                                                                  |

--- a/PrefireExecutable/Sources/PrefireCore/PrefireGenerator.swift
+++ b/PrefireExecutable/Sources/PrefireCore/PrefireGenerator.swift
@@ -130,7 +130,17 @@ public enum PrefireGenerator {
             
             var fileArguments = arguments
             fileArguments["previewsMacrosDict"] = models as NSArray
-            
+
+            // Resolve the placeholder in any string-valued arguments so values like the
+            // `file` path (used by SnapshotTesting to derive the per-class `__Snapshots__`
+            // folder) point at the per-source generated file rather than a literal placeholder.
+            for (key, value) in fileArguments {
+                guard let stringValue = value as? NSString,
+                      stringValue.contains("{PREVIEW_FILE_NAME}") else { continue }
+                let resolved = (stringValue as String).replacingOccurrences(of: "{PREVIEW_FILE_NAME}", with: fileName)
+                fileArguments[key] = resolved as NSString
+            }
+
             // Replace the placeholder in the template as well
             let customizedTemplate = inlineTemplate.replacingOccurrences(of: "{PREVIEW_FILE_NAME}", with: fileName)
             

--- a/PrefireExecutable/Sources/prefire/Commands/Tests/GenerateTestsCommand.swift
+++ b/PrefireExecutable/Sources/prefire/Commands/Tests/GenerateTestsCommand.swift
@@ -22,6 +22,7 @@ struct GeneratedTestsOptions {
     var imports: [String]?
     var testableImports: [String]?
     var useGroupedSnapshots: Bool
+    var splitSnapshotDirectories: Bool
     var drawHierarchyInKeyWindowDefaultEnabled: Bool?
 
     init(
@@ -55,6 +56,7 @@ struct GeneratedTestsOptions {
         self.device = config?.tests.device ?? device
         self.osVersion = config?.tests.osVersion ?? osVersion
         useGroupedSnapshots = config?.tests.useGroupedSnapshots ?? true
+        splitSnapshotDirectories = config?.tests.splitSnapshotDirectories ?? false
         snapshotDevices = config?.tests.snapshotDevices
         imports = config?.tests.imports
         testableImports = config?.tests.testableImports
@@ -96,7 +98,16 @@ enum GenerateTestsCommand {
     }
 
     static func makeArguments(for options: GeneratedTestsOptions) async -> [String: NSObject] {
-        let snapshotOutput = options.testTargetPath.flatMap({ $0 + Constants.snapshotFileName })
+        // `split_snapshot_directories` works only together with `use_grouped_snapshots: false`,
+        // because each `__Snapshots__/<name>/` folder is derived from a distinct generated `.swift`
+        // file. Warn instead of silently ignoring so the user notices the misconfiguration.
+        if options.splitSnapshotDirectories && options.useGroupedSnapshots {
+            Logger.warning("⚠️ `split_snapshot_directories: true` requires `use_grouped_snapshots: false` and will be ignored otherwise.")
+        }
+
+        let splitDirectories = options.splitSnapshotDirectories && !options.useGroupedSnapshots
+        let snapshotFileName = splitDirectories ? Constants.snapshotFileTemplated : Constants.snapshotFileName
+        let snapshotOutput = options.testTargetPath.flatMap({ $0 + snapshotFileName })
 
         Logger.info(
             """

--- a/PrefireExecutable/Sources/prefire/Config/Config.swift
+++ b/PrefireExecutable/Sources/prefire/Config/Config.swift
@@ -24,6 +24,7 @@ struct TestsConfig {
     var imports: [String]?
     var testableImports: [String]?
     var useGroupedSnapshots: Bool?
+    var splitSnapshotDirectories: Bool?
     var drawHierarchyInKeyWindowDefaultEnabled: Bool?
 
     enum CodingKeys: String, CodingKey {
@@ -39,6 +40,7 @@ struct TestsConfig {
         case imports = "imports"
         case testableImports = "testable_imports"
         case useGroupedSnapshots = "use_grouped_snapshots"
+        case splitSnapshotDirectories = "split_snapshot_directories"
         case drawHierarchyInKeyWindowDefaultEnabled = "draw_hierarchy_in_key_window_default_enabled"
     }
 }

--- a/PrefireExecutable/Sources/prefire/Config/ConfigDecoder.swift
+++ b/PrefireExecutable/Sources/prefire/Config/ConfigDecoder.swift
@@ -72,6 +72,8 @@ final class ConfigDecoder {
             config.tests.testTargetPath = getValue(from: components.last, env: env)
         case .useGroupedSnapshots:
             config.tests.useGroupedSnapshots = getValue(from: components.last, env: env) == "true"
+        case .splitSnapshotDirectories:
+            config.tests.splitSnapshotDirectories = getValue(from: components.last, env: env) == "true"
         case .drawHierarchyInKeyWindowDefaultEnabled:
             config.tests.drawHierarchyInKeyWindowDefaultEnabled = getValue(from: components.last, env: env) == "true"
         }

--- a/PrefireExecutable/Tests/PrefireTests/GenerateTestsCommandTest.swift
+++ b/PrefireExecutable/Tests/PrefireTests/GenerateTestsCommandTest.swift
@@ -49,6 +49,34 @@ class GenerateTestsCommandTests: XCTestCase {
         XCTAssertEqual(YAMLParser().string(from: arguments), YAMLParser().string(from: expectedArguments))
     }
     
+    func test_makeArguments_split_snapshot_directories_uses_templated_file_name() async {
+        options.useGroupedSnapshots = false
+        options.splitSnapshotDirectories = true
+
+        let expectedArguments = [
+            "mainTarget": "\(options.target ?? "")" as NSString,
+            "file": options.testTargetPath.flatMap({ $0 + "{PREVIEW_FILE_NAME}Tests.generated.swift" })!.string as NSString,
+        ] as [String: NSObject]
+
+        let arguments = await GenerateTestsCommand.makeArguments(for: options)
+
+        XCTAssertEqual(YAMLParser().string(from: arguments), YAMLParser().string(from: expectedArguments))
+    }
+
+    func test_makeArguments_ungrouped_without_split_keeps_legacy_file_name() async {
+        options.useGroupedSnapshots = false
+        options.splitSnapshotDirectories = false
+
+        let expectedArguments = [
+            "mainTarget": "\(options.target ?? "")" as NSString,
+            "file": options.testTargetPath.flatMap({ $0 + "PreviewTests.generated.swift" })!.string as NSString,
+        ] as [String: NSObject]
+
+        let arguments = await GenerateTestsCommand.makeArguments(for: options)
+
+        XCTAssertEqual(YAMLParser().string(from: arguments), YAMLParser().string(from: expectedArguments))
+    }
+
     func test_makeArguments_drawHierarchyInKeyWindowDefaultEnabled() async {
         options.drawHierarchyInKeyWindowDefaultEnabled = true
 

--- a/PrefireExecutable/Tests/PrefireTests/PrefireGeneratorTests.swift
+++ b/PrefireExecutable/Tests/PrefireTests/PrefireGeneratorTests.swift
@@ -101,6 +101,37 @@ final class PrefireGeneratorTests: XCTestCase {
         XCTAssertTrue(result.contains("class PreviewTests: XCTestCase"), "Should use 'Preview' as class name for grouped snapshots")
     }
     
+    func testUngroupedFileGenerationResolvesPlaceholderInArguments() async throws {
+        let file = Path(fixtureTestPreviewSource)
+        let outputTemplate = Path("/tmp/{PREVIEW_FILE_NAME}Tests.generated.swift")
+        let cache = Path("/tmp/cache/")
+        let template = "// snapshot file: {{ argument.file }}"
+        let args: [String: NSObject] = [
+            "file": "/Users/dev/Tests/{PREVIEW_FILE_NAME}Tests.generated.swift" as NSString
+        ]
+
+        try await PrefireGenerator.generate(
+            version: "1.0.0",
+            sources: [file],
+            output: outputTemplate,
+            arguments: args,
+            inlineTemplate: template,
+            defaultEnabled: true,
+            cacheDir: cache,
+            useGroupedSnapshots: false
+        )
+
+        let expectedOutput = Path("/tmp/TestPreviewTests.generated.swift")
+        XCTAssertTrue(expectedOutput.exists, "Should generate ungrouped file with filename")
+
+        let result = try expectedOutput.read(.utf8)
+        XCTAssertTrue(
+            result.contains("// snapshot file: /Users/dev/Tests/TestPreviewTests.generated.swift"),
+            "Should resolve {PREVIEW_FILE_NAME} in string-valued arguments so the `file` path points at the per-source generated file"
+        )
+        XCTAssertFalse(result.contains("{PREVIEW_FILE_NAME}"), "Placeholder should not leak into the rendered output")
+    }
+
     func testUngroupedFileGenerationUsesFileNameInClassName() async throws {
         let file = Path(fixtureTestPreviewSource)
         let outputTemplate = Path("/tmp/{PREVIEW_FILE_NAME}Tests.generated.swift")


### PR DESCRIPTION
## Summary

Fixes #80 — when `use_grouped_snapshots: false`, snapshots still landed in a single shared `__Snapshots__/PreviewTests.generated/` folder even though Prefire generated separate `<File>Tests.generated.swift` files per source.

Adds an opt-in `split_snapshot_directories` config flag (default `false`) that fixes this.

## Root cause

Since #135 (`use_grouped_snapshots: false`) Prefire emits one `.swift` test file per source (`ButtonViewTests.generated.swift`, `CartViewTests.generated.swift`, …). But the `Keys.file` argument passed into the Stencil template — used as `private var file: StaticString` and forwarded to every `assertSnapshot(file: file, ...)` — was hardcoded to `<test_target_path>/PreviewTests.generated.swift` in `GenerateTestsCommand.makeArguments`.

`swift-snapshot-testing` derives `__Snapshots__/<basename(file) without .swift>/` from that path. Same `file:` in every class ⇒ everything ends up in `__Snapshots__/PreviewTests.generated/`, regardless of how many separate classes Prefire emitted.

## Fix

Two surgical edits + one new config flag:

1. **`GenerateTestsCommand.makeArguments`** picks `Constants.snapshotFileTemplated` (`{PREVIEW_FILE_NAME}Tests.generated.swift`) instead of `Constants.snapshotFileName` when both `use_grouped_snapshots: false` and `split_snapshot_directories: true`.
2. **`PrefireGenerator.generateUngroupedFiles`** resolves the `{PREVIEW_FILE_NAME}` placeholder inside any string-valued argument (i.e. `file`) per iteration, mirroring the existing placeholder resolution it already does on `inlineTemplate` and `output`.
3. New config key `split_snapshot_directories` plumbed through `Config.TestsConfig`, `ConfigDecoder`, and `GeneratedTestsOptions`.

If the user combines `split_snapshot_directories: true` with `use_grouped_snapshots: true`, the flag is ignored with a warn-log explaining why (one shared `.swift` ⇒ one shared folder).

## Behaviour matrix

| `use_grouped_snapshots` | `split_snapshot_directories` | Result |
|---|---|---|
| `true` (default) | `false` (default) | Unchanged: 1 file `PreviewTests.generated.swift`, all snapshots in `__Snapshots__/PreviewTests.generated/`. |
| `true` | `true` | Warn-log; flag ignored (one shared `.swift` cannot split folders via `file:`). |
| `false` | `false` (default) | Unchanged backward-compat after #135: N `.swift` files, but `file:` still shared ⇒ snapshots still in one folder. Keeps existing snapshot files in place after upgrade. |
| `false` | `true` | **New** — `file:` is per-source ⇒ snapshots land in `__Snapshots__/<File>Tests.generated/` per source. Closes #80. |

## Minimal config to enable the new layout

```yaml
test_configuration:
  use_grouped_snapshots: false
  split_snapshot_directories: true
  test_file_path: "Tests/{PREVIEW_FILE_NAME}Tests.generated.swift"
```

## Migration note

Default-off is deliberate. Projects already on `use_grouped_snapshots: false` keep their current `__Snapshots__/PreviewTests.generated/` layout untouched after upgrading. Opting in is a content-move that the user controls — either move existing PNGs into the new `<File>Tests.generated/` subfolders, or wipe and re-record.

## Test plan

- [x] `cd PrefireExecutable && swift test` — 41/41 pass, including 3 new tests:
  - `GenerateTestsCommandTests.test_makeArguments_split_snapshot_directories_uses_templated_file_name`
  - `GenerateTestsCommandTests.test_makeArguments_ungrouped_without_split_keeps_legacy_file_name`
  - `PrefireGeneratorTests.testUngroupedFileGenerationResolvesPlaceholderInArguments`
- [x] `swift build -c release` clean
- [x] End-to-end CLI run on `Example/Shared` with `use_grouped_snapshots:false + split_snapshot_directories:true` → each generated `<File>Tests.generated.swift` contains its own `private var file: StaticString { ... "<File>Tests.generated.swift" }`, no `{PREVIEW_FILE_NAME}` leftover.
- [x] End-to-end CLI run on `Example/Shared` with legacy `use_grouped_snapshots:false` only (no `split`) → all 3 classes still reference the shared `PreviewTests.generated.swift`, confirming backward compatibility.