### PR TITLE
Rebuild bundled CLI on release so it doesn't ship a stale binary

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Rebuild bundled binary from current source
+        run: make binary
       - name: Create achrive
         run: make archive
       - name: Release

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,13 @@ update:
 	mv Binaries/PrefireBinary.artifactbundle/prefire-$(CUR_VERSION)-macos/ Binaries/PrefireBinary.artifactbundle/prefire-$(version)-macos/
 	cd Binaries/PrefireBinary.artifactbundle; sed -i '' -e '6 s/.*/            "version": "$(version)",/g' info.json
 	cd Binaries/PrefireBinary.artifactbundle; sed -i '' -e '9 s/.*/                    "path": "prefire-$(version)-macos\/bin\/prefire",/g' info.json
-	cd Binaries/PrefireBinary.artifactbundle; sed -i '' -e '9 s/.*/                    "path": "prefire-$(version)-macos\/bin\/prefire",/g' info.json
 	cd PrefireExecutable/Sources/prefire/Commands/Version/; sed -i '' -e '8 s/.*/        static let value: String = "$(version)"/g' Version.swift
+
+	# Rebuild bundled CLI so the artifactbundle matches the new Version.swift
+	# constant. Without this step the binary committed in the release tag
+	# keeps reporting the previous version (see history: 5.5.0/5.6.0 both
+	# shipped a binary whose `--version` prints 5.4.1).
+	$(MAKE) binary
 
 archive:
 	tar -czf prefire.tar.gz -C Binaries/PrefireBinary.artifactbundle/prefire-${CUR_VERSION}-macos/bin/ prefire


### PR DESCRIPTION
## TL;DR

The release pipeline currently ships a stale CLI: bundled `prefire-X.Y.Z-macos/bin/prefire` reports `--version` = `5.4.1` regardless of what release tag you check out, because `make update` only renames the directory and rewrites metadata — it never rebuilds the binary. As a result, config keys added after 5.4.1 are silently ignored at runtime even when the Swift sources in the release contain them.

## How I noticed

I bumped a downstream project to 5.6.0 to pick up [#163](https://github.com/BarredEwe/Prefire/pull/163) (`split_snapshot_directories`). The plugin happily generated per-source `<File>Tests.generated.swift` files (thanks, `use_grouped_snapshots: false` works), but the `file:` baked into every `assertSnapshot` call stayed at the legacy `PreviewTests.generated.swift`. So snapshot directories were still collapsing into one shared folder.

Tracing the runtime to `Binaries/PrefireBinary.artifactbundle/prefire-5.6.0-macos/bin/prefire`:

```
$ Binaries/PrefireBinary.artifactbundle/prefire-5.6.0-macos/bin/prefire --version
5.4.1

$ Binaries/PrefireBinary.artifactbundle/prefire-5.6.0-macos/bin/prefire tests --help
# (no flags added past 5.4.1; ConfigDecoder for the new keys isn't there)
```

Confirmed by checksum that the binary in a fresh `git clone --branch 5.6.0` is byte-identical to the one in our local SPM cache (`53652dcc960772c087175262acc04d92b80b90cf8f0d012bb0b7d5db7ff97f7f`), so this is what the release ships.

## Root cause

The release commit for 5.6.0 (`178ee10`) does three things — none of them rebuild the binary:

```
:100644 100644 73da8f0 564355c M    Binaries/.../info.json
:100755 100755 52f3e35 52f3e35 R100 Binaries/.../prefire-5.5.0-macos/bin/prefire
                                  → Binaries/.../prefire-5.6.0-macos/bin/prefire
:100644 100644 c6bbccb a0781d7 M    PrefireExecutable/.../Version.swift
```

The `R100` line is the smoking gun — the binary blob hash is unchanged from 5.5.0, it's just a directory rename. And looking at `Makefile`:

```makefile
update:
    mv Binaries/.../prefire-$(CUR_VERSION)-macos/ Binaries/.../prefire-$(version)-macos/
    sed -i ... info.json                # version + path
    sed -i ... Version.swift            # static let value
    # no `swift build` anywhere
```

`make update version=X.Y.Z` was designed to be the only pre-release step, but it leaves the binary as-is. `.github/workflows/publish.yml` then runs `make archive` on tag push, which just `tar`s up whatever is committed:

```makefile
archive:
    tar -czf prefire.tar.gz -C Binaries/.../prefire-${CUR_VERSION}-macos/bin/ prefire
```

So the maintainer has to remember to run `make binary` by hand before `make update`. If they don't (which is what happened in 5.4.2 → 5.5.0 and 5.5.0 → 5.6.0), the binary inside the artifactbundle silently keeps its old contents.

## Fix

Two changes:

**1. `Makefile` — `update` now rebuilds the binary as its last step.**

`update` already runs `sed` on `Version.swift` before this point, so the rebuild picks up the new `Version.value` constant. The recursive `$(MAKE) binary` re-evaluates `CUR_VERSION` from the already-renamed directory, so the rebuilt binary lands in the new `prefire-<new>-macos/bin/` rather than the old one.

```diff
 update:
     mv .../prefire-$(CUR_VERSION)-macos/ .../prefire-$(version)-macos/
     sed -i ... info.json
-    sed -i ... info.json   # duplicate of the line above
     sed -i ... Version.swift
+
+    $(MAKE) binary
```

(Also dropped a duplicate `sed` on `info.json` line 9 that was a no-op — it ran the same substitution twice.)

**2. `.github/workflows/publish.yml` — `make binary` before `make archive`.**

Defense in depth — even if a future `make update` skips the rebuild, or someone hand-edits `Version.swift` without running `update`, CI guarantees the published `.tar.gz` contains a freshly-built binary from the current source.

```diff
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Rebuild bundled binary from current source
+        run: make binary
       - name: Create achrive
         run: make archive
```

## Not in scope

This PR doesn't ship a fresh `5.6.0` binary in the artifactbundle — that needs a follow-up release tag (`5.6.1`?), and I'd rather have you cut it yourself than commit a rebuilt binary from my machine. Once this merges, the next tag push will produce a correct artifact automatically.

## Test plan

- [x] `make binary` builds clean on my mac (Apple Silicon, Xcode 26.5).
- [x] The resulting `prefire --version` reports `5.6.0` and `tests --help` now lists the new config behavior.
- [ ] Maintainer cuts a 5.6.1 (or re-tags 5.6.0 if comfortable with that) to publish a working binary.
